### PR TITLE
Link GTI to EVENTS via DSS header keys

### DIFF
--- a/source/events/index.rst
+++ b/source/events/index.rst
@@ -23,6 +23,10 @@ keywords to be contained in each FITS event list is also documented. Many of the
 keywords are not necessarily required for an analysis. The information is,
 however, included as meta data in the event lists to enable instrument-dependent
 studies and selections of particular observations.
+Since GTIs are specific to the event list they must be stored in the same file as the event list.
+To ensure consistency, the event list header must contain a reference to the GTI extension. This reference
+is stored using DSS keywords (See `here <https://cta-redmine.irap.omp.eu/attachments/download/1822/SDS07.pdf>`__ (sect 1.13) and `here
+<https://cta-redmine.irap.omp.eu/attachments/download/1823/fits_standard30aa.pdf>`__).
 
 Required Column Names
 ---------------------
@@ -137,6 +141,18 @@ Required Header keywords:
 * ``ALTITUDE`` type: float, unit: km
     * Altitude of array center above sea level (1.835 for HESS)
 
+Required header keywords to link GTI extension
+----------------------------------------------
+
+* ``DSTYP1`` type: string
+    * Type of DS keyword, should be "TIME"
+* ``DSUNI1`` type: string
+    * Unit of GTIs, should be "s"
+* ``DSVAL1`` type: string
+    * GTI type, should be "TABLE"
+* ``DSREF1`` type: string
+    * Name of GTI extension (starting with colon), should e.g. be ":GTI"
+
 Optional header keywords
 ------------------------
 
@@ -203,10 +219,11 @@ values are in units of seconds with respect to the reference time defined in the
 associated header (keywords MJDREFI and MJDREFF). This extension allows for a
 detailed handling of good time intervals (i.e. excluding periods with cloud
 cover or lightning during one observation). Eventually, this extension could
-disappear from the required extensions. High-level Science tools could add the
-GTIs to the files according to user parameter. See e.g. `gtmktime`_ for an
+disappear from the required extensions. High-level Science tools could update the
+GTIs in the files according to user parameter. See e.g. `gtmktime`_ for an
 application example from the Fermi Science Tools. The column names and FITS
-header keywords are documented in the following, respectively.
+header keywords are documented in the following, respectively. The GTIs should be linked
+from the corresponding event list.
 
 GTI Column Names
 ----------------


### PR DESCRIPTION
This pull request proposes to link GTI to a given EVENTS via data sub-space (DSS) header keywords, as used by Fermi-LAT and others.

[edit: title and description made more clear by @cdeil on 2016-02-28]
