### PR TITLE
Specify IRF axis orders

### DIFF
--- a/source/irfs/background/index.rst
+++ b/source/irfs/background/index.rst
@@ -51,20 +51,25 @@ Header keywords:
 
 Columns:
 
-* ``bkg`` unit: s^-1 MeV^-1 sr^-1
+* ``THETA_LO``, ``THETA_HI`` -- ndim: 1, unit: deg
+    * Field of view offset axis
+    * Binning is often chosen with a square root scale,
+      so that each ``THETA`` bin has equal solid angle,
+      which means bins at the center of the field of view
+      have smaller width ``THETA_HI - THETA_LO``.
+* ``ENERG_LO``, ``ENERG_HI`` -- ndim: 1, unit: TeV
+    * Energy axis
+* ``BKG`` ndim: 2, unit: s^-1 MeV^-1 sr^-1
     * Absolute post-select background rate
       (expected background per time, energy and solid angle).
     * Note that this is not a "flux" or "surface brightness".
       This is already a count rate, it doesn't need to be multiplied with
       effective area to obtain predicted counts, like gamma-ray flux and
       surface brightness models do.
-* ``THETA_LO``, ``THETA_HI`` (deg)
-    * Field of view offset from the pointing position binning, see :ref:`sky-coordinates-fov`
-* ``ENERG_LO``, ``ENERG_HI`` (TeV)
-    * Energy binning, see TODO
 
-TODO: explain a bit about the THETA axis, i.e. that bins are usually
-chosen to have a constant solid angle per bin, i.e. with sqrt spacing.
+The ``BKG`` array is 2-dimensional:
+* Axis order: THETA, ENERGY
+* Shape: (len(THETA), len(ENERGY))
 
 Example data file: TODO
 
@@ -81,17 +86,21 @@ store energy in TeV?
 
 Columns:
 
-* ``bkg`` unit: s^-1 MeV^-1 sr^-1
+* ``ENERG_LO``, ``ENERG_HI`` -- ndim: 1, unit: TeV
+    * Energy axis
+* ``DETX_LO``, ``DETX_HI``, ``DETY_LO``, ``DETY_HI`` -- ndim: 1, unit: deg
+    * Field of view coordinates binning, see :ref:`sky-coordinates-fov`
+* ``BKG`` -- ndim: 3, unit: s^-1 MeV^-1 sr^-1
     * Absolute post-select background rate
       (expected background per time, energy and solid angle).
     * Note that this is not a "flux" or "surface brightness".
       This is already a count rate, it doesn't need to be multiplied with
       effective area to obtain predicted counts, like gamma-ray flux and
       surface brightness models do.
-* ``DETX_LO``, ``DETX_HI``, ``DETY_LO``, ``DETY_HI`` (deg)
-    * Field of view coordinates binning, see :ref:`sky-coordinates-fov`
-* ``ENERG_LO``, ``ENERG_HI`` (TeV)
-    * Energy binning, see TODO
+
+The ``BKG`` array is 3-dimensional:
+* Axis order: ENERGY, DETX, DETY
+* Shape: (len(ENERGY), len(DETX), len(DETY))
 
 Header keywords:
 

--- a/source/irfs/background/index.rst
+++ b/source/irfs/background/index.rst
@@ -67,9 +67,7 @@ Columns:
       effective area to obtain predicted counts, like gamma-ray flux and
       surface brightness models do.
 
-The ``BKG`` array is 2-dimensional:
-* Axis order: THETA, ENERGY
-* Shape: (len(THETA), len(ENERGY))
+Recommended axis order: ``ENERGY``, ``THETA``
 
 Example data file: TODO
 
@@ -98,9 +96,7 @@ Columns:
       effective area to obtain predicted counts, like gamma-ray flux and
       surface brightness models do.
 
-The ``BKG`` array is 3-dimensional:
-* Axis order: ENERGY, DETX, DETY
-* Shape: (len(ENERGY), len(DETX), len(DETY))
+Recommended axis order for ``BKG``: ``ENERGY``, ``DETX``, ``DETY``
 
 Header keywords:
 

--- a/source/irfs/effective_area/index.rst
+++ b/source/irfs/effective_area/index.rst
@@ -35,9 +35,7 @@ Columns:
 * ``EFFAREA_RECO`` -- ndim: 2, unit: deg
     * Effective area value as a function of reco energy
 
-The ``EFFAREA`` and ``EFFAREA_RECO`` arrays are 2-dimensional:
-* Axis order: THETA, ENERGY
-* Shape: (len(THETA), len(ENERGY))
+Recommended axis order: ``ENERGY``, ``THETA``
 
 Header keywords:
 

--- a/source/irfs/effective_area/index.rst
+++ b/source/irfs/effective_area/index.rst
@@ -21,33 +21,31 @@ will likely be included in future releases.
 ``aeff_2d`` format
 ------------------
 
-Valid names for the extension holding the effective area are ``EFFECTIVE AREA``
-and ``aeff_2d``. The effective area information is saved as a
-:ref:`fits-arrays-bintable-hdu` with required columns listed below. In addition
-to the standard header keywords the recommended energy range for the observation
-corresponding to the effective area file is stored in two additional header.
-Another optional header keyword contains the theta squared cut that was applied
-in the case of a effective area generation for point-like sources.
-
-An example file is provided  :download:`here <./aeff_2d_example.fits>`.
+The effective area information is saved as a :ref:`fits-arrays-bintable-hdu`
+with required columns listed below.
 
 Columns:
 
-* ``ENERG_LO`` type: float, unit: TeV
-    * Lower energy bin edges 
-* ``ENERG_HI`` type: float, unit: TeV
-    * Upper energy bin edges 
-* ``THETA_LO`` type: float, unit: deg
-    * Lower offset bin edges
-* ``THETA_HI`` type: float, unit: deg
-    * Upper offset bin edges
-* ``EFFAREA`` type: float, dimensions: 2
-    * Matrix holding the effective area for a given true energy and offset.
-* ``EFFAREA_RECO`` type: float, dimensions: 2
-    * Matrix holding the effective area for a given reconstructed energy and offset.
-    * TODO: Is this still up-to-date?
+* ``THETA_LO``, ``THETA_HI`` -- ndim: 1, unit: deg
+    * Field of view offset axis
+* ``ENERG_LO``, ``ENERG_HI`` -- ndim: 1, unit: TeV
+    * Energy axis
+* ``EFFAREA`` -- ndim: 2, unit: none
+    * Effective area value as a function of true energy
+* ``EFFAREA_RECO`` -- ndim: 2, unit: deg
+    * Effective area value as a function of reco energy
+
+The ``EFFAREA`` and ``EFFAREA_RECO`` arrays are 2-dimensional:
+* Axis order: THETA, ENERGY
+* Shape: (len(THETA), len(ENERGY))
 
 Header keywords:
+
+In addition to the standard header keywords the recommended energy range for the
+observation corresponding to the effective area file is stored in two additional
+header keywords. Another optional header keyword contains the theta squared cut
+that was applied in the case of a effective area generation for point-like
+sources.
 
 * ``OBS_ID`` type: int
     * Observation ID, run number
@@ -57,3 +55,5 @@ Header keywords:
     * High energy threshold
 * ``RAD_MAX`` type: float, unit: deg
     * On region radius for point-like observations
+
+An example file is provided  :download:`here <./aeff_2d_example.fits>`.

--- a/source/irfs/energy_dispersion/index.rst
+++ b/source/irfs/energy_dispersion/index.rst
@@ -52,18 +52,15 @@ Columns:
 * ``MATRIX`` type: float, dimensions: 3 
     * Matrix holding the probability for a given energy migration at a certain true energy and offset.
 
+* ``ENERG_LO``, ``ENERG_HI`` -- ndim: 1, unit: TeV
+    * Energy axis
 * ``THETA_LO``, ``THETA_HI`` -- ndim: 1, unit: deg
     * Field of view offset axis
 * ``MIGRA_LO``, ``MIGRA_HI`` -- ndim: 1, unit: dimensionless
     * Energy migration axis (defined above)
-* ``ENERG_LO``, ``ENERG_HI`` -- ndim: 1, unit: TeV
-    * Energy axis
 * ``MATRIX`` -- ndim: 3, unit: dimensionless
     * Energy dispersion :math:`dP/d\mu`, see formula above.
 
-The ``MATRIX`` array is three-dimensional:
-* Axis order: THETA, MIGRA, ENERGY
-* Shape: (len(THETA), len(MIGRA), len(ENERGY))
-
+Recommended axis order: ``ENERGY``, ``MIGRA``, ``THETA``
 
 Header keywords: none

--- a/source/irfs/energy_dispersion/index.rst
+++ b/source/irfs/energy_dispersion/index.rst
@@ -44,25 +44,26 @@ reconstructed energy band *J*.
 ``edisp_2d`` format
 -------------------
 
-Valid names for the extension holding the energy dispersion are ``ENERGY
-DISPERSION`` and ``edisp_2d``. The energy dispersion information is saved as a
+The energy dispersion information is saved as a
 :ref:`fits-arrays-bintable-hdu` with the following required columns.
 
 Columns:
 
-* ``ETRUE_LO`` type: float, unit: TeV
-    * Lower true energy bin edges 
-* ``ETRUE_HI`` type: float, unit: TeV
-    * Upper true energy bin edges 
-* ``THETA_LO`` type: float, unit: deg
-    * Lower offset bin edges
-* ``THETA_HI`` type: float, unit: deg
-    * Upper offset bin edges
-* ``MIGRA_LO`` type: float
-    * Energy migration lower bin edges
-* ``MIGRA_HI`` type: float
-    * Energy migration upper bin edges
 * ``MATRIX`` type: float, dimensions: 3 
     * Matrix holding the probability for a given energy migration at a certain true energy and offset.
+
+* ``THETA_LO``, ``THETA_HI`` -- ndim: 1, unit: deg
+    * Field of view offset axis
+* ``MIGRA_LO``, ``MIGRA_HI`` -- ndim: 1, unit: dimensionless
+    * Energy migration axis (defined above)
+* ``ENERG_LO``, ``ENERG_HI`` -- ndim: 1, unit: TeV
+    * Energy axis
+* ``MATRIX`` -- ndim: 3, unit: dimensionless
+    * Energy dispersion :math:`dP/d\mu`, see formula above.
+
+The ``MATRIX`` array is three-dimensional:
+* Axis order: THETA, MIGRA, ENERGY
+* Shape: (len(THETA), len(MIGRA), len(ENERGY))
+
 
 Header keywords: none

--- a/source/irfs/index.rst
+++ b/source/irfs/index.rst
@@ -27,8 +27,7 @@ IRF axes
 --------
 
 Most IRFs are dependent on parameters, and the 1-dim. parameter arrays are
-stored in columns. The following names are recommended (TODO: are we consistent
-everywhere for our formats?):
+stored in columns. The following names are recommended:
 
 * For energy grids, see `here <http://heasarc.gsfc.nasa.gov/docs/heasarc/caldb/docs/memos/cal_gen_92_003/cal_gen_92_003.html#tth_sEc7>`__
   for basic recommendations. Column names should be ``ENERGY`` or ``ENERG_LO``, ``ENERG_HI``
@@ -37,6 +36,11 @@ everywhere for our formats?):
 * Sky coordinates should be called ``RA``, ``DEC``, ``GLON``, ``GLAT``, ``ALT``, ``AZ``.
 * Field of view coordinates ``DETX``, ``DETY`` or ``THETA``, ``PHI`` for offset and azimuth angle in the field of view.
 * Offset wrt. the source position should be called ``RAD`` (this is what the OGIP PSF formats use).
+
+The IRF format specs mention a recommended axis format and axis units.
+But tools should not depend on this and instead:
+* Use the axis order specified by the ``CREF`` header keyword (see :ref:`fits-arrays-bintable-hdu`)
+* Use the axis unit specifiec by the ``CUNIT`` header keywords (see :ref:`fits-arrays-bintable-hdu`)
 
 Specific IRFs
 -------------

--- a/source/irfs/psf/psf_3gauss/index.rst
+++ b/source/irfs/psf/psf_3gauss/index.rst
@@ -45,22 +45,21 @@ TODO: give test case value and Python function for easy checking?
 
 Columns:
 
-* ``ENERG_LO``, ``ENERG_HI`` -- 1D, unit: TeV
-    * Energy axis
-* ``THETA_LO``, ``THETA_HI`` -- 1D, unit: deg
+* ``THETA_LO``, ``THETA_HI`` -- ndim: 1, unit: deg
     * Field of view offset axis
-* ``SCALE`` -- 1D, unit: none
+* ``ENERG_LO``, ``ENERG_HI`` -- ndim: 1, unit: TeV
+    * Energy axis
+* ``SCALE`` -- ndim: 2, unit: none
     * Absolute scale of the 1st Gaussian
-* ``SIGMA_1`` -- 1D, unit: deg
-    * Sigma of the 1st Gaussian
-* ``AMPL_2`` -- 1D, unit: none
-    * Relative amplitude of the 2nd Gaussian with respect to the 1st Gaussian
-* ``SIGMA_2`` -- 1D, unit: deg
-    * Sigma of the 2nd Gaussian
-* ``AMPL_3`` -- 1D, unit: none
-    * Relative amplitude of the 3rd Gaussian with respect to the 1st Gaussian
-* ``SIGMA_3`` -- 1D, unit: deg
-    * Sigma of the 3rd Gaussian
+* ``SIGMA_1``, ``SIGMA_2``, ``SIGMA_3`` -- ndim: 2, unit: deg
+    * Model parameter (see formula above)
+* ``AMPL_2``, ``AMPL_3`` -- ndim: 2, unit: none
+    * Model parameter (see formula above)
+
+The ``SCALE``, ``SIGMA_*`` and ``AMPL_*`` arrays are 2-dimensional:
+* Axis order: THETA, ENERGY
+* Shape: (len(THETA), len(ENERGY))
+
 
 Header keywords: none
 

--- a/source/irfs/psf/psf_3gauss/index.rst
+++ b/source/irfs/psf/psf_3gauss/index.rst
@@ -56,10 +56,7 @@ Columns:
 * ``AMPL_2``, ``AMPL_3`` -- ndim: 2, unit: none
     * Model parameter (see formula above)
 
-The ``SCALE``, ``SIGMA_*`` and ``AMPL_*`` arrays are 2-dimensional:
-* Axis order: THETA, ENERGY
-* Shape: (len(THETA), len(ENERGY))
-
+Recommended axis order: ``ENERGY``, ``THETA``
 
 Header keywords: none
 

--- a/source/irfs/psf/psf_king/index.rst
+++ b/source/irfs/psf/psf_king/index.rst
@@ -32,9 +32,7 @@ Columns:
 * ``SIGMA`` -- ndim: 2, unit: deg
     * Model parameter (see formula above)
 
-The ``GAMMA`` and ``SIGMA`` arrays are 2-dimensional:
-* Axis order: THETA, ENERGY
-* Shape: (len(THETA), len(ENERGY))
+Recommended axis order: ``ENERGY``, ``THETA``
 
 Header keywords: none
 

--- a/source/irfs/psf/psf_king/index.rst
+++ b/source/irfs/psf/psf_king/index.rst
@@ -9,7 +9,7 @@ The King function parametrisations for PSFs has been in use in astronomy
 as an analytical PSF model for many instruments, for example
 by the Fermi-LAT (see `2013ApJ...765...54A`_).
 
-The distribution has to parameters gamma :math:`\gamma` and sigma :math:`\sigma`
+The distribution has two parameters ``GAMMA`` :math:`\gamma` and ``SIGMA`` :math:`\sigma`
 and is given by the following formula:
 
 .. math::
@@ -23,14 +23,18 @@ This formula integrates to 1 (see :ref:`psf-intro`).
 
 Columns:
 
-* ``ENERG_LO``, ``ENERG_HI`` -- 1D, unit: TeV
-    * Energy axis
-* ``THETA_LO``, ``THETA_HI`` -- 1D, unit: deg
+* ``THETA_LO``, ``THETA_HI`` -- ndim: 1, unit: deg
     * Field of view offset axis
-* ``GAMMA`` -- 1D, unit: none
-    * gamma parameter of the King-Function 
-* ``SIGMA`` -- 1D, unit: deg
-    * sigma parameter of the King-Function
+* ``ENERG_LO``, ``ENERG_HI`` -- ndim: 1, unit: TeV
+    * Energy axis
+* ``GAMMA`` -- ndim: 2, unit: none
+    * Model parameter (see formula above)
+* ``SIGMA`` -- ndim: 2, unit: deg
+    * Model parameter (see formula above)
+
+The ``GAMMA`` and ``SIGMA`` arrays are 2-dimensional:
+* Axis order: THETA, ENERGY
+* Shape: (len(THETA), len(ENERGY))
 
 Header keywords: none
 

--- a/source/irfs/psf/psf_table/index.rst
+++ b/source/irfs/psf/psf_table/index.rst
@@ -23,8 +23,6 @@ Columns:
 * ``RPSF`` -- ndim: 3, unit: deg^-2
     * Point spread function value :math:`dP/d\Omega`, see :ref:`psf-pdf`.
 
-The ``RPSF`` array is three-dimensional:
-* Axis order: RAD, THETA, ENERGY
-* Shape: (len(RAD), len(THETA), len(ENERGY))
+Recommended axis order: ``RAD``, ``THETA``, ``ENERGY``.
 
 Header keywords: none

--- a/source/irfs/psf/psf_table/index.rst
+++ b/source/irfs/psf/psf_table/index.rst
@@ -9,20 +9,22 @@ This is a PSF FITS format we agree on for IACTs.
 This file contains the offset- and energy-dependent table distribution of the PSF.
 
 This format is almost identical to the `OGIP radial PSF`_ format.
-
-The differences are that we don't have the dependency on azimuthal field of view position and the
-units are different.
+The differences are that we don't have the dependency on azimuthal field of
+view position and the units are different.
 
 Columns:
 
-* ``RAD_LO``, ``RAD_HI`` -- 1D, unit: deg
+* ``RAD_LO``, ``RAD_HI`` -- ndim: 1, unit: deg
     * Offset angle from source position
-* ``THETA_LO``, ``THETA_HI`` -- 1D, unit: deg
+* ``THETA_LO``, ``THETA_HI`` -- ndim: 1, unit: deg
     * Field of view offset axis
-* ``ENERG_LO``, ``ENERG_HI`` -- 1D, unit: TeV
+* ``ENERG_LO``, ``ENERG_HI`` -- ndim: 1, unit: TeV
     * Energy axis
-* ``RPSF`` -- 3D (deg^-2), shape = (len(RAD), len(THETA), len(ENERGY))
+* ``RPSF`` -- ndim: 3, unit: deg^-2
     * Point spread function value :math:`dP/d\Omega`, see :ref:`psf-pdf`.
-    * Axis order: RAD, THETA, ENERGY
+
+The ``RPSF`` array is three-dimensional:
+* Axis order: RAD, THETA, ENERGY
+* Shape: (len(RAD), len(THETA), len(ENERGY))
 
 Header keywords: none


### PR DESCRIPTION
This pull request specifies the IRF axis orders.

It became apparent that this is needed because we accidentally chose an `ENERGY, THETA` order for `BKG_2D`, whereas the current AEFF and PSF formats use `THETA, ENERGY` (see https://github.com/gammapy/gammapy/pull/461#issuecomment-188125729).

I think this pull request is uncontroversial and I'll merge it later today.

Still, @jknodlseder, @mimayer, @JouvinLea, if you could have a look and specifically comment on these questions, that would be useful:
- OK to use `THETA, ENERGY` axis order everywhere? Or is `ENERGY, THETA` better? The main difference is memory access speed ... values that are typically accessed together should be consecutive in memory so that CPU cache performance is better. I haven't thought about  / benchmarked what is better here.
- Does the axis order `ENERGY, DETX, DETY` correspond to the current Gammalib implementation? Or do you have `ENERGY, DETY, DETX`?
- It's a bit weird that we have energy first for 3D and last for 2D, but I guess that's OK?
- Any other thoughts?
