### PR TITLE
Binned Likelihood Formats

### DIFF
--- a/source/results/binned_likelihoods/index.rst
+++ b/source/results/binned_likelihoods/index.rst
@@ -1,0 +1,113 @@
+.. include:: ../../references.txt
+
+.. _binned_likelihoods:
+
+Binned Likelihood Profiles
+==========================
+
+This page describes formats for bin-by-bin likelihood profiles as
+currently used in some LAT analyses.  
+
+
+2D Binned Likelihood
+--------------------
+
+The 2D binned likelihood is a representation of the profile likelihood
+for the normalization of a source vs. energy.  The 2D likelihood can
+be used in the same way as a traditional SED but has the advantage
+that it retains information about the shape of the likelihood function
+around the likelihood maximum.  The proposed format is a BINTABLE with
+the following columns:
+
+* ``E_MIN`` -- ndim: 1, unit: MeV
+    * Dimension: nebins
+    * Lower edge of energy bin.
+* ``E_MAX`` -- ndim: 1, unit: MeV
+    * Dimension: nebins
+    * Upper edge of energy bin.
+* ``EFLUX`` -- ndim: 1, unit: MeV cm^{-2} s^{-1}
+    * Dimension: nebins
+    * Energy flux of best-fit source normalization integrated over the energy bin.
+* ``DFDE`` -- ndim: 1, unit: MeV^{-1} cm^{-2} s^{-1}
+    * Dimension: nebins
+    * Differential flux of best-fit source normalization evaluated at
+      the bin center.
+* ``NPRED`` -- ndim: 1, unit: counts
+    * Dimension: nebins
+    * Number of predicted counts of best-fit source normalization.
+* ``NORM_ERR`` -- ndim: 1, unit: None
+    * Dimension: nebins
+    * Symmetric error on the source normalization.      
+* ``NORM_ERRP`` -- ndim: 1, unit: None
+    * Dimension: nebins
+    * Positive error on the source normalization.
+* ``NORM_ERRN`` -- ndim: 1, unit: None
+    * Dimension: nebins
+    * Negative error on the source normalization.
+* ``NORM_UL`` -- ndim: 1, unit: None
+    * Dimension: nebins
+    * Upper limit on the source normalization.            
+* ``TS`` -- ndim: 1, unit: counts
+    * Dimension: nebins
+    * Source test statistic as a function of energy bin.
+* ``DNLL_SCAN`` -- ndim: 2, unit: None
+    * Dimension: nebins x nnorms
+    * Delta negative LogLikelihood value vs. normalization.  The
+      Delta-Loglikelihood is evaluated with respect to the maximum of
+      the likelihood function in each energy bin.
+* ``NLL_SCAN`` -- ndim: 2, unit: None
+    * Dimension: nebins x nnorms
+    * Absolute negative LogLikelihood value vs. normalization.
+* ``NORMSCAN`` -- ndim: 2, unit: None
+    * Dimension: nebins x nnorms
+    * Normalization scan values in each energy bin expressed as the
+      ratio with respect to the best-fit normalization.  Scan matrix
+      can be multiplied by ``EFLUX``, ``DFDE``, or ``NPRED`` vectors
+      to get the normalization in the respective units.
+      
+TS Cube
+-------
+
+Recent releases of the Fermi ScienceTools provide a *gttscube*
+application which can be used to fit a test source as a function of
+energy and spatial position within the ROI.  The output of this tool
+is a FITS file containing maps that encode the fit results.  The
+PRIMARY HDU contains the same output as *gttsmap* -- a 2-dimensional
+map with the test source test statistic evaluated at each spatial
+pixel.  The other HDUs contain information about the fit results in
+individual energy planes.  The SCANDATA HDU contains the full
+information about the likelihood scan in each energy bin and spatial
+pixel and can be used to reconstruct the likelihood for an arbitrary
+spectral model (not necessarily the test source model).  Here is the
+list of HDUs:
+
+.. csv-table:: TS Cube HDUs
+   :header:    HDU, HDU Type, HDU Name, Dimensions, Description
+   :file: tscube_hdus.csv
+   :delim: |
+   :widths: 10,10,10,10,80
+
+The EBOUNDS HDU is a table with 1 row per energy bin and the following
+columns:
+
+* ``E_MIN``, unit: keV
+    * Lower edge of energy bin.
+* ``E_MAX``, unit: keV
+    * Upper edge of energy bin.
+* ``E_MIN_FL``
+    * Differential flux evaluated at the lower edge of the energy bin.
+* ``E_MAX_FL``
+    * Differential flux evaluated at the upper edge of the energy bin.
+* ``NPRED``
+    * Number of predicted counts in the energy bin.
+  
+The SCANDATA HDU is a table with 1 row per spatial pixel and the
+following columns:
+
+* ``NLL_SCAN`` -- ndim: 2, unit: None
+    * Dimension: nebins X nnorms
+    * Normalization values for the test source.
+* ``NORMSCAN`` -- ndim: 2, unit: None
+    * Dimension: nebins X nnorms
+    * Negative log-likelihood values.
+

--- a/source/results/binned_likelihoods/index.rst
+++ b/source/results/binned_likelihoods/index.rst
@@ -8,7 +8,6 @@ Binned Likelihood Profiles
 This page describes formats for bin-by-bin likelihood profiles as
 currently used in some LAT analyses.  
 
-
 2D Binned Likelihood
 --------------------
 
@@ -16,8 +15,12 @@ The 2D binned likelihood is a representation of the profile likelihood
 for the normalization of a source vs. energy.  The 2D likelihood can
 be used in the same way as a traditional SED but has the advantage
 that it retains information about the shape of the likelihood function
-around the likelihood maximum.  The proposed format is a BINTABLE with
-the following columns:
+around the likelihood maximum.  In the following we use *nebins* to
+designate the number of energy bins and *nnorms* to designate the
+number of points in the normalization scan.  The proposed format is a
+BINTABLE with the following columns.  
+
+Columns:
 
 * ``E_MIN`` -- ndim: 1, unit: MeV
     * Dimension: nebins
@@ -44,9 +47,9 @@ the following columns:
 * ``NORM_ERRN`` -- ndim: 1, unit: None
     * Dimension: nebins
     * Negative error on the source normalization.
-* ``NORM_UL`` -- ndim: 1, unit: None
+* ``NORM_UL95`` -- ndim: 1, unit: None
     * Dimension: nebins
-    * Upper limit on the source normalization.            
+    * 95% C.L. upper limit on the source normalization.            
 * ``TS`` -- ndim: 1, unit: counts
     * Dimension: nebins
     * Source test statistic as a function of energy bin.

--- a/source/results/binned_likelihoods/tscube_hdus.csv
+++ b/source/results/binned_likelihoods/tscube_hdus.csv
@@ -1,0 +1,14 @@
+0|IMAGE    | PRIMARY | nypix X nypix | TS map of the region using the test source
+1|BINTABLE | SCANDATA  | nypix X nypix | Table with the data from the likelihood v. normalization scans
+2|BINTABLE | BASELINE | 1 ROW | Parameters and Covariences of Baseline fit
+3|BINTABLE | EBOUNDS  | nebins ROWS | Energy bin edges, fluxes and NPREDs for test source in each energy bin
+4|IMAGE    | TSMAP_OK | nypix X nypix | Fit status flags for fits at each PIXEL (across the entire energy range)
+5|IMAGE    | N_MAP | nypix X nypix | Normalization values for the test source for each PIXEL (across the entire energy range)
+6|IMAGE    | ERRP_MAP | nypix X nypix | Positive Error on Normalization of Test Source
+7|IMAGE    | ERRN_MAP | nypix X nypix | Negative Error on Normalization of Test Source
+8|IMAGE    | TSCUBE | nypix X nypix X nebins | TS values for each pixel, for each energy bin
+9|IMAGE    | TSCUBE_OK | nypix X nypix X nebins | Fit status flags for fits at each PIXEL, for each energy bin
+10|IMAGE   | N_CUBE | nypix X nypix X nebins | Normalization values for the test source for each PIXEL, for each energy bin
+11|IMAGE   | ERRPCUBE | nypix X nypix X nebins | Positive Error on Normalization of Test Source
+12|IMAGE   | ERRNCUBE | nypix X nypix X nebins | Negative Error on Normalization of Test Source
+13|IMAGE   | NLL_CUBE | nypix X nypix X nebins | Negative log-likelihood at MLE estimate for each PIXEL, for each energy bin

--- a/source/results/binned_likelihoods/tscube_hdus.csv
+++ b/source/results/binned_likelihoods/tscube_hdus.csv
@@ -1,7 +1,7 @@
 0|IMAGE    | PRIMARY | nypix X nypix | TS map of the region using the test source
 1|BINTABLE | SCANDATA  | nypix X nypix | Table with the data from the likelihood v. normalization scans
-2|BINTABLE | BASELINE | 1 ROW | Parameters and Covariences of Baseline fit
-3|BINTABLE | EBOUNDS  | nebins ROWS | Energy bin edges, fluxes and NPREDs for test source in each energy bin
+2|BINTABLE | BASELINE |  | Parameters and Covariences of Baseline fit
+3|BINTABLE | EBOUNDS  | nebins | Energy bin edges, fluxes and NPREDs for test source in each energy bin
 4|IMAGE    | TSMAP_OK | nypix X nypix | Fit status flags for fits at each PIXEL (across the entire energy range)
 5|IMAGE    | N_MAP | nypix X nypix | Normalization values for the test source for each PIXEL (across the entire energy range)
 6|IMAGE    | ERRP_MAP | nypix X nypix | Positive Error on Normalization of Test Source

--- a/source/results/index.rst
+++ b/source/results/index.rst
@@ -13,3 +13,4 @@ other codes (e.g. to check results, combine results in one plot, ...).
 
    flux_points/index
    light_curves/index
+   binned_likelihoods/index


### PR DESCRIPTION
This is a first draft of the bin-by-bin likelihood format that we discussed back at the time of the PyGamma meeting.  Along with the 2D likelihood format I've also included the format that is currently output by *gttscube* -- a new ballistic tool that we recently made available in an internal ST release (11-00-00).  gttscube extends the concept of the bin-by-bin likelihood to 4 dimensions by performing an SED analysis at every spatial bin in the ROI.