### PR TITLE
Change units of table PSF to sr^-1

### DIFF
--- a/source/irfs/psf/psf_table/index.rst
+++ b/source/irfs/psf/psf_table/index.rst
@@ -20,7 +20,7 @@ Columns:
     * Field of view offset axis
 * ``ENERG_LO``, ``ENERG_HI`` -- ndim: 1, unit: TeV
     * Energy axis
-* ``RPSF`` -- ndim: 3, unit: deg^-2
+* ``RPSF`` -- ndim: 3, unit: sr^-1
     * Point spread function value :math:`dP/d\Omega`, see :ref:`psf-pdf`.
 
 Recommended axis order: ``RAD``, ``THETA``, ``ENERGY``.


### PR DESCRIPTION
This PR changes the PSF table units from `deg^-2` to `sr^-1` as suggested by @jknodlseder in #54.
I think there is agreement on this change, merging this now.

If someone comes across this later and disagrees, please comment in #54 or open a new issue or pull request.