### PR TITLE
Add Galactic coordinates as optional columns to EVENTS and OBS_IDX

### DIFF
--- a/source/data_storage/obs_index/index.rst
+++ b/source/data_storage/obs_index/index.rst
@@ -76,6 +76,10 @@ selection or data quality checks or analysis, but aren't needed for most users.
         * Use a name that can be resolved by `SESAME`_
         * For survey observations, use "survey".
         * For :ref:`glossary-obs-off`, use "off observation"
+* ``GLON_PNT`` type: float, unit: deg
+    * Observation pointing Galactic longitude (see :ref:`coords-galactic`).
+* ``GLAT_PNT`` type: float, unit: deg
+    * Observation pointing Galactic latitude (see :ref:`coords-galactic`).
 * ``RA_OBJ`` type: float, unit: deg
     * Right ascension of ``OBJECT``
 * ``DEC_OBJ`` type: float, unit: deg

--- a/source/events/events.rst
+++ b/source/events/events.rst
@@ -55,6 +55,10 @@ Optional columns
 
 * ``EVENT_TYPE`` tform: ``32X``
     * Event quality partition.
+* ``GLON`` tform: ``1E``, unit: deg
+    * Reconstructed event Galactic longitude (see :ref:`coords-galactic`).
+* ``GLAT`` tform: ``1E``, unit: deg
+    * Reconstructed event Galactic latitude (see :ref:`coords-galactic`).
 * ``ALT`` tform: ``1E``, unit: deg
     * Reconstructed altitude coordinate of event
       (horizon system, see :ref:`coords-altaz`)


### PR DESCRIPTION
This pull request addresses #27 and adds optional columns for Galactic coordinates to the EVENTS and observation index spec. 

Merging this now.
