### PR TITLE
Make DETX / DETY optional in EVENTS

### DIFF
--- a/source/events/events.rst
+++ b/source/events/events.rst
@@ -33,14 +33,6 @@ Mandatory columns
 * ``ENERGY`` tform: ``1E``, unit: TeV
     * Reconstructed event energy.
       See also the `OGIP event list`_ standard.
-* ``DETX`` tform: ``1E``, unit: deg
-    * Reconstructed event X-coordinate in detector system
-      (nominal system, see :ref:`coords-fov`).
-      See also the `OGIP event list`_ standard.
-* ``DETY`` tform: ``1E``, unit: deg
-    * Reconstructed event Y-coordinate in detector system
-      (nominal system, see :ref:`coords-fov`).
-      See also the `OGIP event list`_ standard.
 
 
 Optional columns
@@ -65,6 +57,14 @@ Optional columns
 * ``AZ`` tform: ``1E``, unit: deg
     * Reconstructed azimuth coordinate of event
       (horizon system, see :ref:`coords-altaz`)
+* ``DETX`` tform: ``1E``, unit: deg
+    * Reconstructed event X-coordinate in detector system
+      (nominal system, see :ref:`coords-fov`).
+      See also the `OGIP event list`_ standard.
+* ``DETY`` tform: ``1E``, unit: deg
+    * Reconstructed event Y-coordinate in detector system
+      (nominal system, see :ref:`coords-fov`).
+      See also the `OGIP event list`_ standard.
 * ``THETA`` tform: ``1E``, unit: deg
     * Reconstructed offset from the observation pointing position
 * ``PHI`` tform: ``1E``, unit: deg


### PR DESCRIPTION
This PR makes the DETX / DETY columns in the EVENTS table optional.

This was the conclusion of the discussion in #15 (where no-one implemented it) and also in the IACT DL3 telcon this week:
https://github.com/open-gamma-ray-astro/2016-04_IACT_DL3_Meeting/blob/master/notes/2016-06-07-IACT_DL3_Telcon.md#minutes

I'm trying to keep the pull requests easily readable, so will make the other agreed changes to FOV coordinates in a separate pull request.

Merging this now.