### PR TITLE
Change EVENT_ID from 32 bit to 64 bit int

### DIFF
--- a/source/events/events.rst
+++ b/source/events/events.rst
@@ -16,7 +16,7 @@ The recommended extension name of the binary table is ``EVENTS``.
 Mandatory columns
 -----------------
 
-* ``EVENT_ID`` tform: ``1J``
+* ``EVENT_ID`` tform: ``1K``
     * Event identification number at the DL3 level
       (lower data levels could be different, see note below).
 * ``TIME`` tform: ``1D``, unit: s

--- a/source/events/events.rst
+++ b/source/events/events.rst
@@ -279,8 +279,8 @@ at low data levels and is already fixed for existing IACTs, we propose here
 to have an ``EVENT_ID`` that is simpler and works the same for all IACTs at
 the DL3 level.
 
-As an example: for H.E.S.S. we achive this by using an INT64 for ``EVENT_ID``
-and to store ``EVENT_ID = (BUNCH_ID_HESS << 32) || (EVENT_ID_HESS)``, i.e.
+As an example: for H.E.S.S. we achieve this by using an INT64 for ``EVENT_ID``
+and to store ``EVENT_ID = (BUNCH_ID_HESS << 32) | (EVENT_ID_HESS)``, i.e.
 use the upper bits to contain the low-level bunch ID and the lower bits
 to contains the low-level event ID.
 This encoding is unique and reversible, i.e. it's easy to go back to

--- a/source/general/index.rst
+++ b/source/general/index.rst
@@ -23,4 +23,5 @@ It's purpose is two-fold:
   time
   coordinates
   fits-arrays
+  notes
   glossary

--- a/source/general/notes.rst
+++ b/source/general/notes.rst
@@ -1,0 +1,29 @@
+.. _notes:
+
+Notes
+=====
+
+Here we collect miscellaneous notes that are helpful when reading or working with the specs.
+
+FITS BINTABLE TFORM data type codes
+-----------------------------------
+
+The valid FITS BINTABLE TFORM data type codes are given in this table in the FITS standard paper in
+`table 18 <http://www.aanda.org/articles/aa/full_html/2010/16/aa15362-10/T18.html>`__
+
+Information on how to use it correctly via CFITSIO is
+`here <https://heasarc.gsfc.nasa.gov/docs/software/fitsio/c/c_user/node20.html>`__
+
+For `astropy.io.fits <http://docs.astropy.org/en/stable/io/fits/index.html>`__, there's these
+dicts to translate FITS BINTABLE TFORM codes to Numpy dtype codes::
+
+
+    >>> from astropy.io.fits.column import FITS2NUMPY, NUMPY2FITS
+    >>> FITS2NUMPY
+    {'J': 'i4', 'I': 'i2', 'L': 'i1', 'E': 'f4', 'M': 'c16', 'B': 'u1', 'K': 'i8', 'C': 'c8', 'D': 'f8', 'A': 'a'}
+    >>> NUMPY2FITS
+    {'i1': 'L', 'c16': 'M', 'i4': 'J', 'f2': 'E', 'i2': 'I', 'b1': 'L', 'i8': 'K', 'u8': 'K', 'u1': 'B', 'u4': 'J', 'u2': 'I', 'c8': 'C', 'f8': 'D', 'f4': 'E', 'a': 'A'}
+
+But normally you never should have to manually handle these dtypes from Python.
+``astropy.io.fits`` or ``astropy.table.Table`` will read and write the
+TFORM FITS header keys correctly for you.


### PR DESCRIPTION
This PR:

- changes the event list `EVENT_ID` field from TFORM `1J` (32 bit) to `1K` (64 bit)
- adds a `source/general/notes` section and a short explanation / reference concerning FITS BINTABLE TFORM data type codes.

This change in `EVENT_ID` dtype was discussed for a long time in HESS and the IACT DL3 group.
The event list spec even has this explanation why we want / need 64-bit `EVENT_ID` for HESS:
http://gamma-astro-data-formats.readthedocs.io/en/latest/events/events.html#event-id-column

As far as I know, this change is uncontroversial by now, so I will merge this PR now.
If that is not the case, please comment here and we'll re-open the discussion on this point.

There's an issue in the HESS FITS data tracker here discussing this internally, and also a check that 64-bit event list can be read and processed just fine by Gammalib / ctools:
https://github.com/gammasky/hess-host-analyses/issues/6

cc @bkhelifi  @jknodlseder @mimayer @joleroi 