### PR TITLE
Add E^2 dnde to SED format?

### DIFF
--- a/source/results/flux_points/index.rst
+++ b/source/results/flux_points/index.rst
@@ -50,10 +50,13 @@ and ``e_max`` columns.  Differential representations are quantities
 evaluated at a discrete energies defined by the ``e_ref`` column.  The
 supported :ref:`norm_columns` are:
 
-* ``dnde`` : Differential photon flux at ``e_ref``. Dimensionality:
-  photons / (time * area * energy)
-* ``rate`` : Photon rate between ``e_min`` and ``e_max``. Dimensionality:
-  photons / time.
+* ``dnde`` : Differential photon flux at ``e_ref``.
+  Dimensionality: photons / (time * area * energy)
+* ``e2dnde`` : Defined as ``(e_ref ^ 2) * dnde``.
+  A commonly published and plotted differential flux quantity.
+  Dimensionality: energy / (time * area)
+* ``rate`` : Photon rate between ``e_min`` and ``e_max``.
+  Dimensionality: photons / time.
 * ``flux`` : Photon flux (integral of ``dnde``) between ``e_min`` and
   ``e_max``. Dimensionality: photons / ( time * area )
 * ``eflux`` : Energy flux (integral of E times ``dnde``) between
@@ -153,6 +156,7 @@ columns that must be present in the SED.  The SED types and their
 required columns are given in the following list:
 
 * ``dnde``: ``e_ref``, ``dnde``
+* ``e2dnde``: ``e_ref``, ``e2dnde``
 * ``flux``: ``e_min``, ``e_max``, ``flux``
 * ``eflux``: ``e_min``, ``e_max``, ``eflux``
 * ``likelihood``: See :ref:`likelihood_sed`.
@@ -219,6 +223,10 @@ Normalization Columns
     * Dimension: nebins
     * ucd : ``phot.flux.density``
     * Measured differential photon flux at ``e_ref``. 
+* ``e2dnde`` -- ndim: 1, unit: MeV / (cm2 s)
+    * Dimension: nebins
+    * ucd : ``phot.flux.density``
+    * Measured differential photon flux at ``e_ref``, multiplied with ``e_ref ^ 2``.
 * ``flux`` -- ndim: 1, unit: ph / (cm2 s)
     * Dimension: nebins
     * ucd : ``phot.count``

--- a/source/results/flux_points/index.rst
+++ b/source/results/flux_points/index.rst
@@ -70,6 +70,9 @@ An SED should contain at least one of the normalization
 representations listed above.  Multiple representations (e.g. ``flux``
 and ``dnde``) may be included in a single SED.
 
+The ``dnde`` and ``e2dnde`` representations are equivalent. We define
+both here, because both are in common use for publications and plots.
+
 Errors and upper limits on the normalization are defined with the
 :ref:`error_columns` by appending the appropriate suffix to the
 normalization column name.  For example in the case of photon flux the


### PR DESCRIPTION
While implementing support for the SED format in Gammapy (see https://github.com/gammapy/gammapy/pull/810), @adonath noticed today something.

The spec currently defines `eflux` as an integral quantity, per energy bin:
> eflux : Energy flux (integral of E times dnde) between e_min and e_max. Dimensionality: energy / ( time * area )

I missed that and had assumed that `eflux` is defined as the value commonly shown in "SED" plots, the differential quantity `(e_ref ^ 2) * dnde`.

Concretely in gamma-cat, there's this published HESS SED that was given as `(e_ref ^ 2) * dnde` in the paper, and I put the values incorrectly as `eflux = (e_ref ^ 2) * dnde`:
https://github.com/gammapy/gamma-cat/blob/1815c4f14d3e369356f0e55d7885cd4792b6b051/input/papers/2016/2016arXiv160908671H/tev-000096.ecsv

Here's one other published HESS SED from a year ago where the values given are `(e_ref ^ 2) * dnde` and the column is called `e_Flux` there:
https://www.mpi-hd.mpg.de/hfm/HESS/pages/publications/auxiliary/auxinfo_HESSJ1018

So we think that there's a need to be able to store `(e_ref ^ 2) * dnde` and propose to add a new column `e2dnde` for that. That would satisfy our use cases and would only be a small change.

@woodmd - OK?
Or would you prefer some other solution?
Can you change the spec or should I make a PR?