### PR TITLE
Use "full" less where not needed (to be simpler)

### DIFF
--- a/source/data_storage/hdu_index/index.rst
+++ b/source/data_storage/hdu_index/index.rst
@@ -65,26 +65,18 @@ Valid ``HDU_TYPE`` values (others optional):
 Valid ``HDU_CLASS`` values:
 
 * ``events`` - see format spec: :ref:`iact-events`
-* ``gti`` - see format spec: TODO
-* ``aeff_2d_full`` - see format spec: :ref:`aeff_2d_full`
-* ``edisp_2d_full`` - see format spec: :ref:`edisp_2d_full`
-* ``psf_table_full`` - see format spec: :ref:`psf-table_full`
-* ``psf_3gauss_full`` - see format spec: :ref:`psf_3gauss_full`
-* ``psf_king_full`` - see format spec: :ref:`psf_king_full`
-* ``psf_gtpsf_full`` -- see format spec: :ref:`psf_gtpsf_full`
-* ``bkg_2d_full`` - see format spec: :ref:`bkg_2d_full`
-* ``bkg_3d_full`` - see format spec: :ref:`bkg_3d_full`
+* ``gti`` - see format spec: :ref:`iact-gti`
+* ``aeff_2d`` - see format spec: :ref:`aeff_2d`
+* ``edisp_2d`` - see format spec: :ref:`edisp_2d`
+* ``psf_table`` - see format spec: :ref:`psf-table`
+* ``psf_3gauss`` - see format spec: :ref:`psf_3gauss`
+* ``psf_king`` - see format spec: :ref:`psf_king`
+* ``psf_gtpsf`` -- see format spec: :ref:`psf_gtpsf`
+* ``bkg_2d`` - see format spec: :ref:`bkg_2d`
+* ``bkg_3d`` - see format spec: :ref:`bkg_3d`
 
 We recommend that HDU names are chosen to be identical to either the ``HDU_TYPE``
 or the ``HDU_CLASS`` names mentioned above. This is not a requirement, usually
 end users will access data via HDU index files and the HDU names don't matter.
 Or, if HDUs are accessed directly, the package or tool should be flexible to
 allow loading the HDU with any name.
-
-Future ideas
-------------    
-
-* Not required columns are for future usage when downloading and syncing files with a server.
-* We keep in mind to incoorporate "CHUNK_ID" column to support splitting of runs into chunks.
-
-.. _hdu-index-header:

--- a/source/general/hduclass.rst
+++ b/source/general/hduclass.rst
@@ -8,7 +8,7 @@ HDU classes
 Following NASA's recommendation 
 (see `HFWG Recommendation R8 <http://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/general/ogip_94_006/ogip_94_006.html>`__), 
 a hierarchical classification is applied to each HDU within DL3 FITS files, 
-using the HDUCLASS and HDUCLASn keywords.
+using the ``HDUCLASS`` and ``HDUCLASn`` keywords.
 
 Some useful links from other projects:
 
@@ -20,29 +20,21 @@ Some useful links from other projects:
 
 The different HDUs defined in the current specifications are listed here:
 
-* EVENTS: Table containing the event lists. See :ref:`iact-events`.
-
-* GTI: Table containing the Good Time Intervals ('GTIs') for the event list. See :ref:`iact-gti`.
-
-* POINTING: Table containing the pointing direction of the telescopes for a number of time stamps. See :ref:`iact-pnt`.
-
-* RESPONSE: Table containing any of the different instrument response function components defined in the specs. See :ref:`iact-irf`. 
+* ``EVENTS`` : Table containing the event lists.
+  See :ref:`iact-events`.
+* ``GTI`` : Table containing the Good Time Intervals ('GTIs') for the event list. See :ref:`iact-gti`.
+* ``POINTING`` : Table containing the pointing direction of the telescopes for a number of time stamps. See :ref:`iact-pnt`.
+* ``RESPONSE`` : Table containing any of the different instrument response function components defined in the specs. See :ref:`iact-irf`.
 
 The current HDU class scheme used is the following:
 
-* HDUCLASS: General identifier of the data format. Recommended value: "CTA"
-
-* HDUDOC: Link to the DL3 specifications documentation
-
-* HDUVERS: Version of the DL3 specification format
-
-* HDUCLAS1: General type of HDU, currently: ``EVENTS``, ``GTI`` or ``RESPONSE``
-
-* HDUCLAS2: In case of ``RESPONSE`` type, refers to the IRF components stored within the HDU: ``EFF_AREA``, ``BKG``, ``EDISP`` or ``RPSF``
-
-* HDUCLAS3: In case of ``RESPONSE`` type, refers to the way the IRF component was produced (``POINT-LIKE`` or ``FULL-ENCLOSURE``)
-
-* HDUCLAS4: In case of ``RESPONSE`` type, refers to the name of the specific format
+* ``HDUCLASS`` : General identifier of the data format. Recommended value: "CTA"
+* ``HDUDOC`` : Link to the DL3 specifications documentation
+* ``HDUVERS`` : Version of the DL3 specification format
+* ``HDUCLAS1`` : General type of HDU, currently: ``EVENTS``, ``GTI`` or ``RESPONSE``
+* ``HDUCLAS2`` : In case of ``RESPONSE`` type, refers to the IRF components stored within the HDU: ``EFF_AREA``, ``BKG``, ``EDISP`` or ``RPSF``
+* ``HDUCLAS3`` : In case of ``RESPONSE`` type, refers to the way the IRF component was produced (``POINT-LIKE`` or ``FULL-ENCLOSURE``)
+* ``HDUCLAS4`` : In case of ``RESPONSE`` type, refers to the name of the specific format
 
 
 +-----------+------------+-----------------+--------------+

--- a/source/irfs/full_enclosure/background/index.rst
+++ b/source/irfs/full_enclosure/background/index.rst
@@ -7,15 +7,15 @@ Background format
 
 Here we specify two formats for the background template models (see :ref:`bkg`) of a full-enclosure IRF:
 
-* ``bkg_2d_full`` models depend on ``ENERGY`` and ``THETA``, i.e. are radially symmetric.
-* ``bkg_3d_full`` models depend on ``ENERGY`` and field of view coordinates ``DETX`` and ``DETY``.
+* ``bkg_2d`` models depend on ``ENERGY`` and ``THETA``, i.e. are radially symmetric.
+* ``bkg_3d`` models depend on ``ENERGY`` and field of view coordinates ``DETX`` and ``DETY``.
 
-.. _bkg_2d_full:
+.. _bkg_2d:
 
-``bkg_2d_full``
----------------
+``bkg_2d``
+----------
 
-The ``bkg_2d_full`` format contains a 2-dimensional array of post-select background
+The ``bkg_2d`` format contains a 2-dimensional array of post-select background
 rate, stored in the :ref:`fits-arrays-bintable-hdu` format.
 
 Required columns:
@@ -53,12 +53,12 @@ declare the type of HDU:
 
 Example data file: TODO
 
-.. _bkg_3d_full:
+.. _bkg_3d:
 
-``bkg_3d_full``
----------------
+``bkg_3d``
+----------
 
-The ``bkg_3d_full`` format contains a 3-dimensional array of post-select background
+The ``bkg_3d`` format contains a 3-dimensional array of post-select background
 rate, stored in the :ref:`fits-arrays-bintable-hdu` format.
 
 Required columns:

--- a/source/irfs/full_enclosure/effective_area/index.rst
+++ b/source/irfs/full_enclosure/effective_area/index.rst
@@ -9,10 +9,10 @@ Here we specify the format to store the effective area (see :ref:`iact-aeff`) of
 IRF. It is possible to store as a function of the true energy or as a function 
 of the reconstructed energy.
 
-.. _aeff_2d_full:
+.. _aeff_2d:
 
-``aeff_2d_full``
-----------------
+``aeff_2d``
+-----------
 
 Effective Area vs true energy
 +++++++++++++++++++++++++++++
@@ -58,14 +58,14 @@ declare the type of HDU:
     
 The recommended ``EXTNAME`` keyword is "EFFECTIVE AREA".
 
-.. _aeff_reco_2d_full:
+.. _aeff_reco_2d:
 
 Effective Area vs reconstructed energy
 ++++++++++++++++++++++++++++++++++++++
 
 The effective area as a function of the reconstructed energy, may be stored as
 an additional HDU within  the FITS file, following an analog format as described
-in ``aeff_2d_full``:
+in ``aeff_2d``:
 
 Columns:
 
@@ -99,7 +99,7 @@ declare the type of HDU:
 * ``HDUCLAS4`` = 'AEFF_2D_RECO'
 
 
-Same header keywords as in ``aeff_2d_full`` are required, while the ``EXTNAME`` keyword is recommended to
+Same header keywords as in ``aeff_2d`` are required, while the ``EXTNAME`` keyword is recommended to
 be "EFFECTIVE AREA (RECO)".
 
 Note within the IRFs, we label the true energy as ``ENERGY`` and the
@@ -107,4 +107,4 @@ reconstructed energy as ``ERECO``, while in the  event lists ``ENERGY`` refers
 to the reconstructed energy. Although it may be formally inconsistent, this
 convention follows  current standards.
 
-An example file is provided  :download:`here <./aeff_2d_full_example.fits>`.
+Example data file: :download:`here <./aeff_2d_full_example.fits>`.

--- a/source/irfs/full_enclosure/energy_dispersion/index.rst
+++ b/source/irfs/full_enclosure/energy_dispersion/index.rst
@@ -1,14 +1,14 @@
-.. _iact-edisp-full-format:
+.. _iact-edisp-format:
 
 Energy dispersion format
 ========================
 
 The format to store full-enclosure energy dispersion (see :ref:`iact-edisp`) is the following:
 
-.. _edisp_2d_full:
+.. _edisp_2d:
 
-``edisp_2d_full``
------------------
+``edisp_2d``
+------------
 
 The energy dispersion information is saved as a
 :ref:`fits-arrays-bintable-hdu` with the following required columns.

--- a/source/irfs/full_enclosure/psf/psf_3gauss/index.rst
+++ b/source/irfs/full_enclosure/psf/psf_3gauss/index.rst
@@ -1,13 +1,12 @@
 .. include:: ../../../../references.txt
 
-.. _psf_3gauss_full:
+.. _psf_3gauss:
 
-``psf_3gauss_full``
-===================
+``psf_3gauss``
+==============
 
 Multi-Gauss mixture models are a common way to model distributions
-(for source intensity profiles, PSFs, anything really), see e.g.
-`2013PASP..125..719H`_.
+(for source intensity profiles, PSFs, anything really), see e.g. `2013PASP..125..719H`_.
 For H.E.S.S., radial PSFs have been modeled as 1, 2 or 3 two-dimensional
 Gaussians :math:`dP/d\Omega`.
 
@@ -71,4 +70,4 @@ declare the type of HDU:
 * ``HDUCLAS3`` = 'FULL-ENCLOSURE'
 * ``HDUCLAS4`` = 'PSF_3GAUSS'  
 
-Example data file: TODO: add HESS HAP example file as soon as available.
+Example data file: TODO

--- a/source/irfs/full_enclosure/psf/psf_gtpsf/index.rst
+++ b/source/irfs/full_enclosure/psf/psf_gtpsf/index.rst
@@ -1,8 +1,8 @@
 .. include:: ../../../../references.txt
 
-.. _psf_gtpsf_full:
+.. _psf_gtpsf:
 
-``gtpsf_full``
+``gtpsf``
 ==============
 
 The FITS file has the following BinTable HDUs / columns:

--- a/source/irfs/full_enclosure/psf/psf_king/index.rst
+++ b/source/irfs/full_enclosure/psf/psf_king/index.rst
@@ -1,8 +1,8 @@
 .. include:: ../../../../references.txt
 
-.. _psf_king_full:
+.. _psf_king:
 
-``psf_king_full``
+``psf_king``
 =================
 
 The King function parametrisations for PSFs has been in use in astronomy
@@ -47,4 +47,4 @@ declare the type of HDU:
 * ``HDUCLAS3`` = 'FULL-ENCLOSURE'
 * ``HDUCLAS4`` = 'PSF_KING'  
 
-Example data file: TODO: add HESS HAP example file as soon as available.
+Example data file: TODO

--- a/source/irfs/full_enclosure/psf/psf_table/index.rst
+++ b/source/irfs/full_enclosure/psf/psf_table/index.rst
@@ -1,9 +1,9 @@
 .. include:: ../../../../references.txt
 
-.. _psf-table_full:
+.. _psf-table:
 
-``psf_table_full``
-==================
+``psf_table``
+=============
 
 This is a PSF FITS format we agree on for IACTs.
 This file contains the offset- and energy-dependent table distribution of the PSF.

--- a/source/irfs/point_like/index.rst
+++ b/source/irfs/point_like/index.rst
@@ -9,7 +9,7 @@ Point-like IRFs has been classically used within the IACT community. Each IRF co
 events surviving an energy dependent directional cut around the assumed source position. 
 
 The format of each point-like IRF component is analog to the ones already described within the full enclosure 
-IRF specifications (see :ref:`full-enclosure-irfs`:), with certain differences listed in this section.
+IRF specifications (see :ref:`full-enclosure-irfs`), with certain differences listed in this section.
 
 Any point-like IRF component should contain the header keyword: 
 
@@ -22,9 +22,8 @@ In addition, binary tables should contain the ``RAD_MAX`` column, containing the
 to calculate the IRF component (unit: deg). As this value is allowed to change as a function of the energy and field 
 of view (FoV) coordinates, the dimension of this column is equal to: 
 
-* -- ndim: 2 in case that the FoV coordinate is ``THETA``
-
-* -- ndim: 3 in case that the FoV coordinates are ``DETX`` and ``DETY`` 
+* ndim: 2 in case that the FoV coordinate is ``THETA``
+* ndim: 3 in case that the FoV coordinates are ``DETX`` and ``DETY``
 
 As an example, the format of a point-like effective area (as a function of the true energy) is shown below. 
 


### PR DESCRIPTION
This PR reverts some of the additions of "full" that @TarekHC did in #79 .

Changing Sphinx labels breaks links to the spec from outside, e.g. from the Gammapy docs:
https://travis-ci.org/gammapy/gammapy/jobs/224927389#L2002

The "full" was added in three places:
- Sphinx labels
- Section titles
- As values in the HDU index tables.

I feel that the way the "full" was added isn't helpful, i.e. no corresponding "point" was added to the spec and then one might just as well leave the distinction up to the HDUCLAS3 keyword.

Gammapy is the only software package affected by this change, so I'm merging this now.
I'll do a few follow-up pull requests in the next days to clean up and go towards the first stable version. I'll keep the PRs small so that the diffs are easy to review.

@TarekHC - If you disagree with any of my edits, let me know and we can talk about it on Skype.

