### PR TITLE
Update recommended value for HDUCLASS in hduclass.rst

### DIFF
--- a/source/general/hduclass.rst
+++ b/source/general/hduclass.rst
@@ -28,7 +28,7 @@ The different HDUs defined in the current specifications are listed here:
 
 The current HDU class scheme used is the following:
 
-* ``HDUCLASS`` : General identifier of the data format. Recommended value: "CTA"
+* ``HDUCLASS`` : General identifier of the data format. Recommended value: "GADF" (for "gamma-astro-data-formats")
 * ``HDUDOC`` : Link to the DL3 specifications documentation
 * ``HDUVERS`` : Version of the DL3 specification format
 * ``HDUCLAS1`` : General type of HDU, currently: ``EVENTS``, ``GTI`` or ``RESPONSE``


### PR DESCRIPTION
This request updates the recommended value for the HDUCLASS header keyword from "CTA" to "GADF" as already introduced e.g. [here](http://gamma-astro-data-formats.readthedocs.io/en/latest/irfs/full_enclosure/aeff/index.html).