### PR TITLE
Fix TIMESYS keyword

### DIFF
--- a/source/events/events.rst
+++ b/source/events/events.rst
@@ -155,7 +155,7 @@ Mandatory header keywords
 * ``TIMEUNIT`` type: string
     * Time unit (e.g. 's')
 * ``TIMESYS`` type: string
-    * Time system (e.g. 'TT', 'MJD', 'JD', 'TJD')
+    * Time system, also referred as time scale (e.g. 'UT', 'UTC', 'TT', 'TAI')
 * ``TIMEREF`` type: string
     * Time reference frame, used for example for barycentric corrections
       (options: 'LOCAL', 'SOLARSYSTEM', 'HELIOCENTRIC', 'GEOCENTRIC')

--- a/source/events/gti.rst
+++ b/source/events/gti.rst
@@ -41,7 +41,7 @@ Mandatory header keywords
 * ``TIMEUNIT`` type: string
     * Time unit (e.g. 's')
 * ``TIMESYS`` type: string
-    * Time system (e.g. 'TT', 'MJD', 'JD', 'TJD')
+    * Time system, also referred as time scale (e.g. 'UT', 'UTC', 'TT', 'TAI') 
 * ``TIMEREF`` type: string
     * Time reference frame, used for example for barycentric corrections
       (options: 'LOCAL', 'SOLARSYSTEM', 'HELIOCENTRIC', 'GEOCENTRIC')


### PR DESCRIPTION
Hi @cdeil @cboisson @jknodlseder  

While exporting IACT data, we found an inconsistency with our ```TIMESYS``` keyword description and other documents.

You can see that, [for example here](http://www.cv.nrao.edu/fits/documents/standards/year2000.txt), that the TIMESYS refers to the time system (or time scale) allowing the following values:

      UTC  Coordinated Universal Time; defined since 1972.
      UT   Universal Time, equal to Greenwich Mean Time (GMT) since 1925;
            the UTC equivalent before 1972;
            see: Explanatory Supplement, p. 76.
      TAI  International Atomic Time; "UTC without the leap seconds";
            31 s ahead of UTC on 1997-07-01.
      IAT  International Atomic Time; deprecated synonym of TAI.
      ET   Ephemeris Time, the predecessor of TT; valid until 1984.
      TT   Terrestrial Time, the IAU standard time scale since 1984;
            continuous with ET and synchronous with (but 32.184 s ahead of)
            TAI.
      TDT  Terrestrial Dynamical Time; =TT.
      TDB  Barycentric Dynamical Time.
      TCG  Geocentric Coordinate Time; runs ahead of TT since 1977-01-01
            at a rate of approximately 22 ms/year.
      TCB  Barycentric Coordinate Time; runs ahead of TDB since 1977-01-01
            at a rate of approximately 0.5 s/year.

@jknodlseder Would this change be ok with ctools? Are you using TIMESYS anywhere?