### PR TITLE
Observatory location keys for headers

### DIFF
--- a/source/events/events.rst
+++ b/source/events/events.rst
@@ -98,6 +98,7 @@ Mandatory header keywords
 -------------------------
 
 The standard FITS reference time header keywords should be used (see :ref:`time-formats`).
+An observatory Earth location should be given as well (see :ref:`coords-location`).
 
 * ``HDUCLASS`` type: string
     * Signal conformance with HEASARC/OGIP conventions (option: 'OGIP'). See :ref:`hduclass`.

--- a/source/events/pointing.rst
+++ b/source/events/pointing.rst
@@ -33,15 +33,9 @@ Mandatory columns
 * ``AZ_PNT`` type: float, unit: deg
     * Pointing azimuth  (see :ref:`coords-altaz`).
 
-
 Mandatory header keywords
 -------------------------
 
 The standard FITS reference time header keywords should be used (see :ref:`time-formats`).
+An observatory Earth location should be given as well (see :ref:`coords-location`).
 
-* ``GEOLON`` type: float, unit: deg
-    * Geographic longitude of array centre
-* ``GEOLAT`` type: float, unit: deg
-    * Geographic latitude of array centre
-* ``GEOALT`` type: float, unit: m
-    * Altitude of array center above sea level

--- a/source/general/coordinates.rst
+++ b/source/general/coordinates.rst
@@ -171,3 +171,36 @@ FOV_RADEC_LAT    Latitude in RADEC FOV system
 FOV_RADEC_THETA  Offset in RADEC FOV system
 FOV_RADEC_PHI    Position angle in RADEC FOV system
 ===============  ==================================
+
+.. _coords-location:
+
+Earth location
+--------------
+
+When working with Alt-Az coordinates or very high-precision times,
+an observatory Earth location is needed. However, note that high-level
+analysis for most use cases does not need this information.
+
+The FITS standard mentions ``OBSGEO-X``, ``OBSGEO-Y``, ``OBSGEO-Z``
+header keys, and we might want to consider using those in the future.
+
+For now, as of 2018, however, the existing IACT FITS data uses the
+following header keys, so their use is encouraged:
+
+* ``GEOLON`` type: float, unit: deg
+    * Geographic longitude of array centre
+* ``GEOLAT`` type: float, unit: deg
+    * Geographic latitude of array centre
+* ``ALTITUDE`` type: float, unit: m
+    * Altitude of array center above sea level
+
+While it is possible in principle to change this for each FITS file,
+in practice the observatory or telescope array centre position is something
+that is chosen once and then used consistently in the event reconstruction
+and analysis. As an example, H.E.S.S. uses the following location and
+FITS header keys::
+
+  GEOLAT  = -23.2717777777778 / latitude of observatory (deg)
+  GEOLON  =  16.5002222222222 / longitude of observatory (deg)
+  ALTITUDE=             1835. / altitude of observatory (m)
+


### PR DESCRIPTION
@jknodlseder @kosack all - How should we store observatory location in the FITS header?

What we mention currently is `GEOLON`, `GEOLAT` and `GEOALT` in the `POINTING` spec:
https://github.com/open-gamma-ray-astro/gamma-astro-data-formats/blame/48988405270a433a89ec6de19c1f4bc0db4bc417/source/events/pointing.rst#L46

For the `EVENTS`, in HESS and for the CTA 1DC files we use `GEOLON`, `GEOLAT` and `ALTITUDE`, e.g. for HESS:
```
GEOLAT  = -23.2717777777778 / latitude of observatory (deg)
GEOLON  = 16.5002222222222 / longitude of observatory (deg)
ALTITUDE=            1835. / altitude of observatory (m)
```
Our spec says nothing what to put for `EVENTS`, but I think we should be consistent with `POINTING`.

The [FITS standard](https://fits.gsfc.nasa.gov/standard40/fits_standard40aa.pdf) only mentions `OBSGEO-X`, `OBSGEO-Y`,  `OBSGEO-Z`, not the keys we use.

Looking around, it seems different telescopes / missions use different keys.

Thoughts?