### PR TITLE
Move contributing info to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,37 @@
 # How to contribute
 
 This page describes how to contribute.
+
+## Edit
+
+The documentation is written in
+[restructured text (RST)](http://www.sphinx-doc.org/en/master/usage/restructuredtext/) and rendered to HTML
+and PDF with [Sphinx](http://www.sphinx-doc.org/en/master/)
+and hosted at [Readthedocs](http://gamma-astro-data-formats.readthedocs.io/).
+
+## Pull request
+
+Everyone can contribute by making a pull request with a change or addition
+to https://github.com/open-gamma-ray-astro/gamma-astro-data-formats or by
+sending comments and feedback via the Github issue tracker, or, for
+high-level and important things, to 
+https://lists.nasa.gov/mailman/listinfo/open-gamma-ray-astro .
+
+## Run Sphinx
+
+We use the Sphinx Readthedocs theme.
+To build the HTML docs locally you first have to install Sphinx.
+
+With pip::
+
+    pip install sphinx sphinx_rtd_theme
+
+If you use conda::
+
+    conda create -n gadf python=3.6 sphinx sphinx_rtd_theme
+    conda activate gadf
+
+Then to build and view the HTML docs locally::
+
+    make html
+    open build/html/index.html

--- a/source/general/about.rst
+++ b/source/general/about.rst
@@ -24,34 +24,7 @@ development and discussion is done openly on Github.
 Especially if you are a software library or tool developer,
 we encourage you to support the formats described here instead of inventing your own.
 
-How to contribute?
-------------------
-
-The documentation is written in `restructured text (RST)`_ and rendered to HTML
-and PDF with `Sphinx`_ and hosted at `Readthedocs`_.
-
-Everyone can contribute by making a pull request with a change or addition
-to https://github.com/open-gamma-ray-astro/gamma-astro-data-formats or by
-sending comments and feedback via the Github issue tracker, or, for
-high-level and important things, to 
-https://lists.nasa.gov/mailman/listinfo/open-gamma-ray-astro .
-
-We use the Sphinx Readthedocs theme as described in this `Sphinx RTD theme FAQ
-entry`_, i.e. to build the HTML docs locally you first have to install Sphinx.
-
-With pip::
-
-    pip install sphinx sphinx_rtd_theme
-
-If you use conda::
-
-    conda create -n gadf python=3.6 sphinx sphinx_rtd_theme
-    conda activate gadf
-
-Then to build and view the HTML docs locally::
-
-    make html
-    open build/html/index.html
+Information how to contribute is given in ``CONTRIBUTING.md``.
 
 References
 ----------


### PR DESCRIPTION
This PR moves the "how to contribute" info from the About page in the spec to a separate `CONTRIBUTING.md` that only appears on Github.

I think that's better than having the technical info e.g. how to install and run Sphinx be part of the spec document.