### PR TITLE
Add first lightcurve spec

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -22,3 +22,4 @@ Table of contents
    data_storage/index
    skymaps/index
    spectra/index
+   lightcurves/index

--- a/source/lightcurves/index.rst
+++ b/source/lightcurves/index.rst
@@ -1,0 +1,30 @@
+.. _lc:
+
+Light curves
+============
+
+For light-curves, we recommend to store the information in an as
+similar format as possible to the one for :ref:`spectra` and specifically :ref:`flux-points`.
+
+For measurements at a given time, a ``TIME`` column should be added,
+for measurements for a given time interval, ``TIME_MIN`` and ``TIME_MAX``
+columns should be added.
+
+As explained in :ref:`time`, times should be given as 64-bit floats,
+using the FITS time standard to specify a reference time point.
+Note that this allows some flexibility, and e.g. the commonly used
+"MJD values" for light curves are supported via these header keys::
+
+    MJDREFI =  0
+    MJDREFF =  0
+    TIMEUNIT= 'd'
+
+Light curve producers are highly encouraged to always give the ``TIMESYS``.
+For archival data this is often not given, and it's unclear if the times
+are e.g. in the ``UTC`` or ``TT`` or some other ``TIMESYS``.
+
+This is a very preliminary description, based on the discussion here:
+https://github.com/open-gamma-ray-astro/gamma-astro-data-formats/pull/61
+
+If someone has time to provide a more detailed description, and to produce
+example files in FITS or possibly also ECSV format, this would be highly welcome.


### PR DESCRIPTION
This PR adds a minimal description / spec for lightcurves, based on the discussion in  #61 .

I'm not a lightcurve person and don't have more time to spend on this, so this is my way of finishing up the old discussion / pull request.

Note that the description ends with a sentence that it's very preliminary. I hope that someone with an interest for this does write a better description and adds example files, and maybe even extends the likelihood profiles to include times and support light curves.