### PR TITLE
Update about and how to contribute page

### DIFF
--- a/source/about.rst
+++ b/source/about.rst
@@ -5,36 +5,52 @@
 About
 =====
 
-What is this?
--------------
+In gamma-ray astronomy, a variety of data formats and proprietary software have
+been traditionally used, often developed for one specific mission or experiment.
+Especially for ground-based imaging atmospheric Cherenkov telescopes (IACTs),
+data and software are mostly private to the collaborations operating the
+telescopes. However, there is a general movement in science towards the use of
+open data and software. In addition, the next-generation IACT instrument, the
+Cherenkov Telescope Array (CTA), will be operated as an open observatory. 
 
-This is a grassroots effort to describe data formats that are in use,
-but are not specified anywhere else. Examples range from FITS format instrument
-response functions for imaging atmospheric Cherenkov telescopes (IACTs)
-to YAML format spectral and spatial model specifications,
-to high-level analysis results like spectra and light curves.
+To work towards open and interoperable data formats for gamma-ray astronomy, we
+have started this open data format specification. This was started at the
+`PyGamma15 workshop`_ in November 2017, followed by a `meeting in April 2016 in
+Meudon`_ and another `meeting in March 2017 in Heidelberg`_. Version
+0.1 of the spec was release in April 2016, version 0.2 in July 2018. You can
+find more information about this effort in `Deil et al. (2017)
+<https://adsabs.harvard.edu/abs/2017AIPC.1792g0006D>`__.
 
-The formats described here and the whole effort are not official in any way,
-i.e. not supported or ratified by any institutes, collaborations or committees.
-In some cases the formats described here will likely be adopted or superceded
-by more official formats in the coming years.
+The scope of this effort is to cover all **high-level** data from gamma-ray
+telescopes, starting at the level of event lists and IRFs, also covering reduced
+IRFs, maps, spectra, light curves, up to source models and catalogs. Both
+pointing (IACT) and slewing (Fermi-LAT, HAWC) telescope data is in scope. To a
+large degree, the formats should also be useful for other astroparticle data,
+e.g. from cosmic rays or neutrinos.
 
-Everyone is welcome to adopt these formats or even contribute,
-development and discussion is done openly on Github.
-Especially if you are a software library or tool developer,
-we encourage you to support the formats described here instead of inventing your own.
+All of the data formats described here at the moment can be, and in practice
+mostly are, stored in FITS. Some experimentation with HDF5 and ECSV is ongoing.
+The data format specifications don't explicity mention the serialisation format,
+but rather the key name and data type for each metadata or data field.
 
-Information how to contribute is given in ``CONTRIBUTING.md``.
+The formats described here are partially in use by current instruments
+(Fermi-LAT, HESS, VERITAS, MAGIC, FACT) as well as in the next-generation
+Cherenkov Telescope Array CTA. Prototyping and support for many of the formats
+here is happening in the CTA science tool prototypes `Gammapy`_ and `ctools`_,
+the data formats are being used e.g. in `gamma-cat`_.
 
-References
-----------
+However, we would like to stress that this is an inofficial effort, the formats
+described here are work in progress and have not been officially adopted by any
+of the mentioned instruments. The expectation is that CTA partially adopt these
+formats, and partially develop new ones in the time frame 2018-2020, and then
+the other IACTs will use the official format chosen by CTA.
 
-Existing FITS specs and recommendations:
-
-* http://fits.gsfc.nasa.gov/fits_home.html
-* http://fits.gsfc.nasa.gov/registry/grouping.html
-
-Existing HEASARC specs and recommendations:
-
-* https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/ofwg_recomm.html
-* http://heasarc.gsfc.nasa.gov/docs/heasarc/caldb/caldb_doc.html
+Development of this data format specification happens at
+https://github.com/open-gamma-ray-astro/gamma-astro-data-formats, information
+how to contribute is given in ``CONTRIBUTING.md`` there. Discussion on major and
+controversial points should happen on the mailing list
+(https://lists.nasa.gov/mailman/listinfo/open-gamma-ray-astro). So far, no
+official decision process exists, so some discussions are stuck because of major
+differences in opinion. Probably, moving forward, decisions will be made not in
+this open forum, but rather by the major instruments via their choices,
+especially CTA.

--- a/source/general/notes.rst
+++ b/source/general/notes.rst
@@ -27,3 +27,16 @@ dicts to translate FITS BINTABLE TFORM codes to Numpy dtype codes::
 But normally you never should have to manually handle these dtypes from Python.
 ``astropy.io.fits`` or ``astropy.table.Table`` will read and write the
 TFORM FITS header keys correctly for you.
+
+References
+----------
+
+Existing FITS specs and recommendations:
+
+* http://fits.gsfc.nasa.gov/fits_home.html
+* http://fits.gsfc.nasa.gov/registry/grouping.html
+
+Existing HEASARC specs and recommendations:
+
+* https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/ofwg_recomm.html
+* http://heasarc.gsfc.nasa.gov/docs/heasarc/caldb/caldb_doc.html

--- a/source/references.txt
+++ b/source/references.txt
@@ -52,3 +52,9 @@
 .. _astropy.coordinates.AstrometricFrame: http://astropy.readthedocs.io/en/latest/api/astropy.coordinates.AstrometricFrame.html
 .. _astropy.coordinates.AltAz: http://astropy.readthedocs.io/en/latest/api/astropy.coordinates.AltAz.html
 .. _Astropy astrometric frames: http://astropy.readthedocs.io/en/latest/coordinates/matchsep.html#astropy-astrometric-frames
+.. _PyGamma15 workshop: http://gammapy.github.io/PyGamma15/
+.. _meeting in April 2016 in Meudon: https://github.com/open-gamma-ray-astro/2016-04_IACT_DL3_Meeting
+.. _meeting in March 2017 in Heidelberg: https://github.com/open-gamma-ray-astro/2017-03_IACT_DL3_Meeting
+.. _Gammapy: http://gammapy.org/
+.. _ctools: http://cta.irap.omp.eu/ctools/
+.. _gamma-cat: https://gamma-cat.readthedocs.io/


### PR DESCRIPTION
The about and how to contribute page should be updated:
http://gamma-astro-data-formats.readthedocs.org/en/latest/info/about.html

Add link to https://lists.nasa.gov/mailman/listinfo/open-gamma-ray-astro
and explain that high-level discussion should go there, detailed discussion in Github issues.

Also, there's people that want to read a PDF and send feedback on that and not use Github,
so we have to point out where to get the latest stable and master PDF version and where to send the comments.
