### PR TITLE
Move EVENTS header keys from required to optional

### DIFF
--- a/source/events/events.rst
+++ b/source/events/events.rst
@@ -19,19 +19,16 @@ Mandatory columns
 We follow the `OGIP event list`_ standard.
 
 * ``EVENT_ID`` type: int64
-    * Event identification number at the DL3 level
-      (lower data levels could be different, see note below).
+    * Event identification number at the DL3 level.
+      See notes on :ref:`iact-events-event-id` below.
 * ``TIME`` type: float64, unit: s
     * Event time (see :ref:`time`)
 * ``RA`` type: float, unit: deg
     * Reconstructed event Right Ascension (see :ref:`coords-radec`).
-      See also `HFWG Recommendation R3`_ for the OGIP standard.
 * ``DEC`` type: float, unit: deg
     * Reconstructed event Declination (see :ref:`coords-radec`).
-      See also `HFWG Recommendation R3`_ for the OGIP standard.
 * ``ENERGY`` type: float, unit: TeV
     * Reconstructed event energy.
-
 
 Optional columns
 ----------------
@@ -127,16 +124,17 @@ An observatory Earth location should be given as well (see :ref:`coords-location
       which positions given in either the header or data are expressed.
       (options: 'ICRS', 'FK5').
       See also `HFWG Recommendation R3`_ for the OGIP standard.
-
-
-Optional header keywords
-------------------------
-
 * ``ORIGIN`` type: string
     * Organisation that created the FITS file.
-* ``OBSERVER`` type: string
-    * Name of observer (e.g. 'Joe Public'). This could be for example the PI
-      of a proposal.
+      This can be the same as ``TELESCOP`` (e.g. "HESS"), but it could
+      also be different if an organisation has multiple telescopes (e.g. "NASA" or "ESO").
+* ``TELESCOP`` type: string
+    * Telescope (e.g. 'CTA', 'HESS', 'VERITAS', 'MAGIC')
+* ``INSTRUME`` type: string
+    * Instrument used to aquire the data contained in the file.
+      Each organisation and telescop has to define this.
+      E.g. for CTA it could be 'North' and 'South', or sub-array configurations,
+      this has not been defined yet.
 * ``CREATOR`` type: string
     * Software that created the file. When appropriate, the value of the
       ``CREATOR`` keyword should also reference the specific version of the
@@ -149,25 +147,26 @@ Optional header keywords
       processing that is performed on the file after it is created.
       For more reading on the OGIP standard, see
       `here <https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/ofwg_recomm/r7.html>`_.
+
+
+Optional header keywords
+------------------------
+
+* ``OBSERVER`` type: string
+    * Name of observer. This could be for example the PI of a proposal.
 * ``CREATED`` type: string
     * Time when file was created in ISO standard date representation
       "ccyy-mm-ddThh:mm:ss" (UTC)
+* ``OBJECT`` type: string
+    * Observed object (e.g. 'Crab')
 * ``RA_OBJ`` type: float, unit: deg
     * Right ascension of ``OBJECT``
 * ``DEC_OBJ`` type: float, unit: deg
     * Declination of ``OBJECT``                
-* ``TELESCOP`` type: string
-    * Telescope (e.g. 'CTA', 'HESS', 'VERITAS', 'MAGIC')
-* ``INSTRUME`` type: string
-    * Instrument used to aquire the data contained in the file
-      (e.g. 'North', 'South')
-* ``OBJECT`` type: string
-    * Observed object (e.g. 'Crab')
 * ``OBS_MODE`` type: string
-    * Observation mode (e.g. 'WOBBLE', 'SCAN', 'SLEW', or any mode that is
-      supported by ``TELESCOP``; string should be upper case)
+    * Observation mode. See notes on :ref:`iact-events-obs-mode` below.
 * ``EV_CLASS`` type: str
-    * Event class (the 'cut' that has been used, e.g. 'STD', 'HARD', 'SOFT')'.
+    * Event class. See notes on :ref:`iact-events-class-type` below.
 * ``TELAPSE`` type: float, unit: s
     * Time interval between start and stop time (``TELAPSE=TSTOP-TSTART``).
       Any gaps due to bad weather, or high background counts and/or other
@@ -205,31 +204,29 @@ Optional header keywords
     * Zenith equivalent mean system trigger rate    
 * ``MUONEFF`` type: float
     * Mean muon efficiency
-    * TODO: define how muon efficiency is defined (it's very tricky to get a
-      comparable number in HESS from HD and PA calibration)
 * ``BROKPIX`` type: float
     * Fraction of broken pixels (0.15 means 15% broken pixels)
 * ``AIRTEMP`` type: float, unit: deg C
    * Mean air temperature at ground during the observation.
 * ``PRESSURE`` type: float, unit: hPa
    * Mean air pressure at ground during the observation.
-* ``NSBLEVEL`` type: float, unit: a.u.
-   * Measure for NSB level
-   * TODO: how is this defined? at least leave a comment if it doesn't have
-     a clear definition and can only be used in one chain.
 * ``RELHUM`` type: float
    * Relative humidity
-   * TODO: link to definition ... wikipedia?
+* ``NSBLEVEL`` type: float, unit: a.u.
+   * Measure for night sky background level
 
+.. _iact-events-notes:
 
 Notes
 -----
 
-EVENT_ID column
-~~~~~~~~~~~~~~~
+This paragraph contains some explanatory notes on some of the columns
+and header keys mentioned above.
 
-This paragraph contains some explanatory notes concerning the requirements
-and recommendations on ``EVENT_ID``.
+.. _iact-events-event-id:
+
+EVENT_ID
+~~~~~~~~
 
 Most analyses with high-level science tools don't need ``EVENT_ID`` information.
 But being able to uniquely identify every event is important, e.g. when
@@ -245,15 +242,93 @@ DL0 level for CTA will be even more complicated, because of the much larger
 number of telescopes and events.
 
 So given that data taking and event identification is different for every IACT
-at low data levels and is already fixed for existing IACTs, we propose here
-to have an ``EVENT_ID`` that is simpler and works the same for all IACTs at
-the DL3 level.
+at low data levels and is already fixed for existing IACTs, we propose here to
+have an ``EVENT_ID`` that is simpler and works the same for all IACTs at the DL3
+level.
 
 As an example: for H.E.S.S. we achieve this by using an INT64 for ``EVENT_ID``
-and to store ``EVENT_ID = (BUNCH_ID_HESS << 32) | (EVENT_ID_HESS)``, i.e.
-use the upper bits to contain the low-level bunch ID and the lower bits
-to contains the low-level event ID.
-This encoding is unique and reversible, i.e. it's easy to go back to
-``BUNCH_ID_HESS`` and ``EVENT_ID_HESS`` for a given ``EVENT_ID``,
-and to low-level checks (e.g. look at the shower images for a given event
-that behaves strangely in reconstructed high-level parameters).
+and to store ``EVENT_ID = (BUNCH_ID_HESS << 32) | (EVENT_ID_HESS)``, i.e. use
+the upper bits to contain the low-level bunch ID and the lower bits to contains
+the low-level event ID. This encoding is unique and reversible, i.e. it's easy
+to go back to ``BUNCH_ID_HESS`` and ``EVENT_ID_HESS`` for a given ``EVENT_ID``,
+and to low-level checks (e.g. look at the shower images for a given event that
+behaves strangely in reconstructed high-level parameters).
+
+.. _iact-events-class-type:
+
+EV_CLASS and EVENT_TYPE
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Currently in this format specification, event class ``EV_CLASS`` is a header key
+(i.e. the same for all events in a given event list) and ``EVENT_TYPE`` is a
+bitfield column (i.e. can have a different value for each event). Both are
+optional at this time, only used as provenance information, not by science tools
+to make any decisions how to analyse the data.
+
+The reason for this is simply that we have not agreed yet on a scheme what event
+class and event type means, and how it should be used by science tools for
+analysis. Developing this will be one of the major topics for the next version
+of the spec. It is likely that a proper definition of event classes and types
+will not be compatible with what is currently defined here, so not filling
+``EV_CLASS`` and ``EVENT_TYPE`` when creating DL3 data is not a bad idea.
+
+To summarise a bit the discussions on this important point in the past years,
+they were mostly done by looking at what Fermi-LAT is doing and some
+prototyping in H.E.S.S. to export DL3 data to FITS.
+
+The scheme in Fermi-LAT for event classes and event types is nicely summarised
+`here
+<https://github.com/gammapy/PyGamma15/blob/gh-pages/talks/fermi2/fermi_advanced_v0.pdf>`__
+or `here
+<https://fermi.gsfc.nasa.gov/ssc/data/analysis/documentation/Cicerone/Cicerone_Data/LAT_DP.html>`__.
+There event classes and types are key parts of the data model, used for EVENT to
+IRF association and even end users need to learn about them and pass event class
+and type information when using science tools.
+
+One option could be to mostly adopt what Fermi-LAT does for IACTs. However, a
+major difference is that Fermi-LAT is a more stable detector, that has a CALDB
+of a very limited number or IRFs that can be used for all data, whereas for
+IACTs with changing telescope configurations, degrading mirrors, changing
+atmosphere, zenith angle, ... most likely we will have to produce per-observation
+IRFs, and then it's easier to bundle the IRFs with the EVENTS in one file,
+and the use of event class and type to link EVENTS and IRFs is no longer needed.
+
+An alternative scheme is to use the term "event class" to describe a given
+analysis configuration. This is e.g. how we currently use ``EV_CLASS`` in
+H.E.S.S., we fill values like "standard" or "hard" or "loose" to describe a
+given full configuration that is the result of a calibration, event
+reconstruction and gamma-hadron separation pipeline. This is similar to what
+Fermi-LAT does, except less sophisticated, the event classes are completely
+independent, there is no nesting, and separate events and IRF files are produced
+for each class/configuration. To analyse data from a given class, the user
+chooses which set of files to download (e.g. "loose" for pulsars or "hard" for a
+bright source where a good PSF is needed), and then the science tools don't need
+to do anything with ``EV_CLASS``, it is just provenance information. Some people
+are experimenting with the use of ``EVENT_TYPE`` in a similar way as Fermi-LAT,
+e.g. to have event quality partitioning based on number of telescopes that saw a
+given event, or other criteria. Again, it is left to users to split events by
+``EVENT_TYPE`` and produce IRFs for each event type and pass those for a joint
+fit to the science tools, as there is no agreement or implementation yet in the
+science tools to support ``EVENT_TYPE`` directly.
+
+So to conclude and summarise again: ``EV_CLASS`` and ``EVENT_TYPE`` as mentioned
+here in this spec are optional and very preliminary. Defining event class and
+type for IACTs needs more prototyping by the science tools and current IACTs and
+CTA and discussion, and then a proposal for a specification.
+
+.. _iact-events-obs-mode:
+
+OBS_MODE 
+~~~~~~~~
+
+The observation mode ``OBS_MODE`` is currently provenance information, not used
+by science tools to decide how to analyse the data. There is no set of defined
+modes yet. Thus, at the moment it is optional.
+
+Just to give an example: in H.E.S.S. the values of "WOBBLE" for wobble
+observations (pointing slightly off target) and "SCAN" for Galactic plane survey
+observation on a grid of sky positions (not wrt. a specific target) is used.
+
+It is likely that ``OBS_MODE`` in the future will be a key piece of information
+in the DL3 data model, defining the observation mode (e.g. pointed, divergent,
+slewing, ...) and being required to analyse the data correctly.

--- a/source/events/events.rst
+++ b/source/events/events.rst
@@ -101,8 +101,42 @@ An observatory Earth location should be given as well (see :ref:`coords-location
     * Version of the format (e.g. '1.0.0'). See :ref:`hduclass`.
 * ``HDUCLAS1`` type: string
     * Primary extension class (option: 'EVENTS'). See :ref:`hduclass`.
+* ``OBS_ID`` type: int
+    * Unique observation identifier (Run number)
+* ``TSTART`` type: float, unit: s
+    * Start time of observation (relative to reference time, see :ref:`time`)
+* ``TSTOP`` type: float, unit: s
+    * End time of observation (relative to reference time, see :ref:`time`)
+* ``ONTIME`` type: float, unit: s
+    * Total *good time* (sum of length of all Good Time Intervals).
+      If a Good Time Interval (GTI) table is provided, ``ONTIME`` should be
+      calculated as the sum of those intervals. Corrections for instrumental
+      *dead time* effects are **NOT** included.
+* ``LIVETIME`` type: float, unit: s
+    * Total time (in seconds) on source, corrected for the *total* instrumental
+      dead time effect.
+* ``DEADC`` type: float
+    * Dead time correction, defined by ``LIVETIME/ONTIME``.
+      Is comprised in [0,1]. Defined to be 0 if ``ONTIME=0``.
+* ``EQUINOX`` type: float
+    * Equinox in years for the celestial coordinate system in which positions
+      given in either the header or data are expressed (options: 2000.0).
+      See also `HFWG Recommendation R3`_ for the OGIP standard.
+* ``RADECSYS`` type: string
+    * Stellar reference frame used for the celestial coordinate system in
+      which positions given in either the header or data are expressed.
+      (options: 'ICRS', 'FK5').
+      See also `HFWG Recommendation R3`_ for the OGIP standard.
+
+
+Optional header keywords
+------------------------
+
 * ``ORIGIN`` type: string
     * Organisation that created the FITS file.
+* ``OBSERVER`` type: string
+    * Name of observer (e.g. 'Joe Public'). This could be for example the PI
+      of a proposal.
 * ``CREATOR`` type: string
     * Software that created the file. When appropriate, the value of the
       ``CREATOR`` keyword should also reference the specific version of the
@@ -115,56 +149,6 @@ An observatory Earth location should be given as well (see :ref:`coords-location
       processing that is performed on the file after it is created.
       For more reading on the OGIP standard, see
       `here <https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/ofwg_recomm/r7.html>`_.
-* ``TELESCOP`` type: string
-    * Telescope (e.g. 'CTA', 'HESS', 'VERITAS', 'MAGIC')
-* ``INSTRUME`` type: string
-    * Instrument used to aquire the data contained in the file
-      (e.g. 'North', 'South')
-* ``OBSERVER`` type: string
-    * Name of observer (e.g. 'Joe Public'). This could be for example the PI
-      of a proposal.
-* ``OBJECT`` type: string
-    * Observed object (e.g. 'Crab')
-* ``OBS_MODE`` type: string
-    * Observation mode (e.g. 'WOBBLE', 'SCAN', 'SLEW', or any mode that is
-      supported by ``TELESCOP``; string should be upper case)
-* ``OBS_ID`` type: int
-    * Unique observation identifier (Run number)
-* ``TSTART`` type: float, unit: s
-    * Start time of observation (relative to reference time, see :ref:`time`)
-* ``TSTOP`` type: float, unit: s
-    * End time of observation (relative to reference time, see :ref:`time`)
-* ``EQUINOX`` type: float
-    * Equinox in years for the celestial coordinate system in which positions
-      given in either the header or data are expressed (options: 2000.0).
-      See also `HFWG Recommendation R3`_ for the OGIP standard.
-* ``RADECSYS`` type: string
-    * Stellar reference frame used for the celestial coordinate system in
-      which positions given in either the header or data are expressed.
-      (options: 'ICRS', 'FK5').
-      See also `HFWG Recommendation R3`_ for the OGIP standard.
-* ``TELAPSE`` type: float, unit: s
-    * Time interval between start and stop time (``TELAPSE=TSTOP-TSTART``).
-      Any gaps due to bad weather, or high background counts and/or other
-      anomalies, are included.
-* ``ONTIME`` type: float, unit: s
-    * Total *good time* (sum of length of all Good Time Intervals).
-      If a Good Time Interval (GTI) table is provided, ``ONTIME`` should be
-      calculated as the sum of those intervals. Corrections for instrumental
-      *dead time* effects are **NOT** included.
-* ``LIVETIME`` type: float, unit: s
-    * Total time (in seconds) on source, corrected for the *total* instrumental
-      dead time effect.
-* ``DEADC`` type: float
-    * Dead time correction, defined by ``LIVETIME/ONTIME``.
-      Is comprised in [0,1]. Defined to be 0 if ``ONTIME=0``.
-* ``EV_CLASS`` type: str
-    * Event class (the 'cut' that has been used, e.g. 'STD', 'HARD', 'SOFT')'.
-
-
-Optional header keywords
-------------------------
-
 * ``CREATED`` type: string
     * Time when file was created in ISO standard date representation
       "ccyy-mm-ddThh:mm:ss" (UTC)
@@ -172,6 +156,22 @@ Optional header keywords
     * Right ascension of ``OBJECT``
 * ``DEC_OBJ`` type: float, unit: deg
     * Declination of ``OBJECT``                
+* ``TELESCOP`` type: string
+    * Telescope (e.g. 'CTA', 'HESS', 'VERITAS', 'MAGIC')
+* ``INSTRUME`` type: string
+    * Instrument used to aquire the data contained in the file
+      (e.g. 'North', 'South')
+* ``OBJECT`` type: string
+    * Observed object (e.g. 'Crab')
+* ``OBS_MODE`` type: string
+    * Observation mode (e.g. 'WOBBLE', 'SCAN', 'SLEW', or any mode that is
+      supported by ``TELESCOP``; string should be upper case)
+* ``EV_CLASS`` type: str
+    * Event class (the 'cut' that has been used, e.g. 'STD', 'HARD', 'SOFT')'.
+* ``TELAPSE`` type: float, unit: s
+    * Time interval between start and stop time (``TELAPSE=TSTOP-TSTART``).
+      Any gaps due to bad weather, or high background counts and/or other
+      anomalies, are included.
 
 .. warning::
    Keywords below seem to be pretty low-level and eventually instrument


### PR DESCRIPTION
The current EVENTS spec has a ton of required header keys:
https://gamma-astro-data-formats.readthedocs.io/en/latest/events/events.html#mandatory-header-keywords

This PR moves the following keys from required to optional:
* ORIGIN
* CREATOR
* TELESCOP
* INSTRUME
* OBSERVER
* OBJECT
* OBS_MODE
* EV_CLASS
* TELAPSE

`TELAPSE` is superfluous, it's defined as `TSTOP - START` which are required. So IMO should be optional.

All of the others are "provenance" information, not used by the science tools.

As far as I can see, all of them are problematic and not well defined.

There is no agreement on observing mode values to use, or how to put event classes or what OBJECT to put for survey operations, or what OBSERVER to put when simulating CTA data now.
So making those keys required when it's not clear what to put is IMO counter-productive.
We can add them back to required when there is a provenance / metadata model for CTA in the future.

Note that very soon all IACTs will release DL3 data and we want to be fully spec compliant, and this question of whether / what to put for these header keys came up.

@cboisson @jknodlseder @kosack @lmohrmann @tony32lin @mackaiver - Please comment.