### PR TITLE
Use upper-case in HDU description headings

### DIFF
--- a/source/events/events.rst
+++ b/source/events/events.rst
@@ -2,8 +2,8 @@
 
 .. _iact-events:
 
-``EVENTS`` extension
-====================
+EVENTS
+======
 
 The ``EVENTS`` extension is a binary FITS table that contains an event list.
 Each row of the table provides information that characterises one event.

--- a/source/events/gti.rst
+++ b/source/events/gti.rst
@@ -2,8 +2,8 @@
 
 .. _iact-gti:
 
-``GTI`` extension
-=================
+GTI
+===
 
 The ``GTI`` extension is a binary FITS table that contains the Good Time
 Intervals ('GTIs') for the event list. A general description of GTIs can
@@ -18,7 +18,6 @@ with cloud cover or lightning during one observation).
 
 High-level Science tools could modify the GTIs according to user parameter.
 See e.g. `gtmktime`_ for an application example from the Fermi Science Tools.
-
 
 Mandatory columns
 -----------------

--- a/source/events/pointing.rst
+++ b/source/events/pointing.rst
@@ -6,8 +6,8 @@
    
 .. _iact-pnt:
 
-``POINTING`` extension
-======================
+POINTING
+========
 
 The ``POINTING`` extension is a binary FITS table that contains for a number
 of time stamps the pointing direction of the telescopes. A *pointing* is here

--- a/source/irfs/full_enclosure/aeff/index.rst
+++ b/source/irfs/full_enclosure/aeff/index.rst
@@ -11,8 +11,8 @@ of the reconstructed energy.
 
 .. _aeff_2d:
 
-``aeff_2d``
------------
+AEFF_2D
+-------
 
 Effective Area vs true energy
 +++++++++++++++++++++++++++++

--- a/source/irfs/full_enclosure/bkg/index.rst
+++ b/source/irfs/full_enclosure/bkg/index.rst
@@ -7,15 +7,15 @@ Background format
 
 Here we specify two formats for the background template models (see :ref:`bkg`) of a full-enclosure IRF:
 
-* ``bkg_2d`` models depend on ``ENERGY`` and ``THETA``, i.e. are radially symmetric.
-* ``bkg_3d`` models depend on ``ENERGY`` and field of view coordinates ``DETX`` and ``DETY``.
+* ``BKG_2D`` models depend on ``ENERGY`` and ``THETA``, i.e. are radially symmetric.
+* ``BKG_3D`` models depend on ``ENERGY`` and field of view coordinates ``DETX`` and ``DETY``.
 
 .. _bkg_2d:
 
-``bkg_2d``
-----------
+BKG_2D
+------
 
-The ``bkg_2d`` format contains a 2-dimensional array of post-select background
+The ``BKG_2D`` format contains a 2-dimensional array of post-select background
 rate, stored in the :ref:`fits-arrays-bintable-hdu` format.
 
 Required columns:
@@ -47,10 +47,10 @@ Example data file: :download:`here <./bkg_2d_full_example.fits>`.
 
 .. _bkg_3d:
 
-``bkg_3d``
-----------
+BKG_3D
+------
 
-The ``bkg_3d`` format contains a 3-dimensional array of post-select background
+The ``BKG_3D`` format contains a 3-dimensional array of post-select background
 rate, stored in the :ref:`fits-arrays-bintable-hdu` format.
 
 Required columns:

--- a/source/irfs/full_enclosure/edisp/index.rst
+++ b/source/irfs/full_enclosure/edisp/index.rst
@@ -7,8 +7,8 @@ The format to store full-enclosure energy dispersion (see :ref:`iact-edisp`) is 
 
 .. _edisp_2d:
 
-``edisp_2d``
-------------
+EDISP_2D
+--------
 
 The energy dispersion information is saved as a
 :ref:`fits-arrays-bintable-hdu` with the following required columns.

--- a/source/irfs/full_enclosure/psf/psf_3gauss/index.rst
+++ b/source/irfs/full_enclosure/psf/psf_3gauss/index.rst
@@ -2,8 +2,8 @@
 
 .. _psf_3gauss:
 
-``psf_3gauss``
-==============
+PSF_3GAUSS
+==========
 
 Multi-Gauss mixture models are a common way to model distributions
 (for source intensity profiles, PSFs, anything really), see e.g. `2013PASP..125..719H`_.

--- a/source/irfs/full_enclosure/psf/psf_gtpsf/index.rst
+++ b/source/irfs/full_enclosure/psf/psf_gtpsf/index.rst
@@ -2,12 +2,11 @@
 
 .. _psf_gtpsf:
 
-``psf_gtpsf``
-=============
+PSF_GTPSF
+=========
 
 The FITS file has the following BinTable HDUs / columns:
 
-* PRIMARY HDU -- empty
 * PSF HDU
     * Energy -- 1D (MeV)
     * Exposure -- 1D (cm^2 s)

--- a/source/irfs/full_enclosure/psf/psf_king/index.rst
+++ b/source/irfs/full_enclosure/psf/psf_king/index.rst
@@ -2,8 +2,8 @@
 
 .. _psf_king:
 
-``psf_king``
-=================
+PSF_KING
+========
 
 The King function parametrisations for PSFs has been in use in astronomy
 as an analytical PSF model for many instruments, for example

--- a/source/irfs/full_enclosure/psf/psf_table/index.rst
+++ b/source/irfs/full_enclosure/psf/psf_table/index.rst
@@ -2,8 +2,8 @@
 
 .. _psf_table:
 
-``psf_table``
-=============
+PSF_TABLE
+=========
 
 This is a PSF FITS format we agree on for IACTs.
 This file contains the offset- and energy-dependent table distribution of the PSF.

--- a/source/irfs/irf_components/index.rst
+++ b/source/irfs/irf_components/index.rst
@@ -142,9 +142,6 @@ Comments
   I.e. if limited event statistics in the PSF computation is an issue,
   it is up to the PSF producer to denoise it to an acceptable level.
 
- 
- 
- 
 .. _bkg:
 
 Background

--- a/source/irfs/point_like/index.rst
+++ b/source/irfs/point_like/index.rst
@@ -17,8 +17,8 @@ Any point-like IRF component should contain the header keyword:
 
 .. _rad_max:
 
-``RAD_MAX``
-+++++++++++
+RAD_MAX
++++++++
 
 In addition to the IRFs, the actual directional cut applied to the data needs to be stored. This cut is allowed
 to be constant or variable along several axes, with a different format.
@@ -42,10 +42,10 @@ table. It stores the values of ``RAD_MAX`` as a function of the reconstructed en
 
 .. _rad_max_2d:
 
-``rad_max_2d``
---------------
+RAD_MAX_2D
+----------
 
-The ``rad_max_2d`` format contains a 2-dimensional array of directional cut values, stored in the
+The ``RAD_MAX_2D`` format contains a 2-dimensional array of directional cut values, stored in the
 :ref:`fits-arrays-bintable-hdu` format.
 
 Required columns:

--- a/source/skymaps/healpix/index.rst
+++ b/source/skymaps/healpix/index.rst
@@ -1,7 +1,5 @@
 .. include:: ../../references.txt
 
-
-
 This page describes data format conventions for FITS binned data and model
 representations pixelized with the `HEALPix algorithm`_.  
 

--- a/source/spectra/ogip/index.rst
+++ b/source/spectra/ogip/index.rst
@@ -21,8 +21,8 @@ OGIP standard in order to meet the requirements of gamma-astronomy.
 
 .. _ogip-pha:
 
-PHA file
---------
+PHA
+---
 
 The OGIP standard PHA file format is described `here
 <https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/spectra/ogip_92_007/node5.html>`__.
@@ -55,8 +55,8 @@ Additional header keyword that can be stored in the PHA header for
 
 .. _ogip-bkg:
 
-BKG file
---------
+BKG
+---
 
 The values of following header keywords need some attention when using them for
 :ref:`glossary-IACT` analysis.
@@ -66,8 +66,8 @@ The values of following header keywords need some attention when using them for
 
 .. _ogip-arf:
 
-ARF file
---------
+ARF
+---
 
 The OGIP standard ARF file format is described `here
 <http://heasarc.gsfc.nasa.gov/docs/heasarc/caldb/docs/memos/cal_gen_92_002/cal_gen_92_002.html#tth_sEc4>`__.
@@ -82,8 +82,8 @@ Additional header keyword that can be stored in the ARF header for
 
 .. _ogip-rmf:
 
-RMF file
---------
+RMF
+---
 
 The OGIP standard RMF file format is described `here
 <http://heasarc.gsfc.nasa.gov/docs/heasarc/caldb/docs/memos/cal_gen_92_002/cal_gen_92_002.html#tth_sEc3.1>`__.


### PR DESCRIPTION
This PR is to address #118 . It consistently puts upper-case strings in the page or section headings, to be consistent with the HDUCLAS keys. Note that this is a cosmetic change, it does not imply any change in the data formats.
