### PR TITLE
Add RA_PNT and DEC_PNT as required header keys in EVENTS

### DIFF
--- a/source/events/events.rst
+++ b/source/events/events.rst
@@ -115,6 +115,10 @@ An observatory Earth location should be given as well (see :ref:`coords-location
 * ``DEADC`` type: float
     * Dead time correction, defined by ``LIVETIME/ONTIME``.
       Is comprised in [0,1]. Defined to be 0 if ``ONTIME=0``.
+* ``RA_PNT`` type: float, unit: deg
+    * Pointing Right Ascension (see :ref:`coords-radec`).
+* ``DEC_PNT`` type: float, unit: deg
+    * Pointing declination (see :ref:`coords-radec`).
 * ``EQUINOX`` type: float
     * Equinox in years for the celestial coordinate system in which positions
       given in either the header or data are expressed (options: 2000.0).


### PR DESCRIPTION
This PR adds back RA_PNT and DEC_PNT as required header keys in EVENTS .

They were initially in, but then removed already in 2016 in #39 .

There was a lot of discussion on that point there, and I think in the end there was agreement that as long as POINTING isn't used much, those header keys should remain, and it was my oversight that they got lost.

@jknodlseder - OK?

@mackaiver - Please add those header keys for your FACT DL3 FITS writer. I think otherwise your data will not work with ctools, and will stop working with Gammapy soon when we change from accessing that info from the obs index files to accessing it from the EVENTS header.

