### PR TITLE
Add FOVALIGN header keyword for background

### DIFF
--- a/source/general/coordinates.rst
+++ b/source/general/coordinates.rst
@@ -196,7 +196,7 @@ both ``(DETX, DETY) = (FOV_ALTAZ_LON, FOV_ALTAZ_LAT)``
 and ``(DETX, DETY) = (FOV_RADEC_LON, FOV_RADEC_LAT)``
 have been used.
 
-To resolve this ambiguity, we propose a header key ``FOVALIGN={ALTAZ,RADEC}'',
+To resolve this ambiguity, we propose a header key ``FOVALIGN={ALTAZ,RADEC}``,
 specifying which definition of field-of-view coordinates is used.
 
 Given the situation that there is no concensus yet, one suggestion is to avoid putting

--- a/source/general/coordinates.rst
+++ b/source/general/coordinates.rst
@@ -197,7 +197,8 @@ and ``(DETX, DETY) = (FOV_RADEC_LON, FOV_RADEC_LAT)``
 have been used.
 
 To resolve this ambiguity, we propose a header key ``FOVALIGN={ALTAZ,RADEC}``,
-specifying which definition of field-of-view coordinates is used.
+specifying which definition of field-of-view coordinates is used. If the key is
+not present, ``FOVALIGN=ALTAZ`` should be assumed as default.
 
 Given the situation that there is no concensus yet, one suggestion is to avoid putting
 FOV coordinates in EVENTS, or if they are added, to clearly state how they are defined.

--- a/source/general/coordinates.rst
+++ b/source/general/coordinates.rst
@@ -191,16 +191,16 @@ In the :ref:`events <iact-events>` table, the column names ``DETX`` and ``DETY``
 are sometimes used. This originates from the `OGIP event list`_ standard,
 which uses these names for "detector coordinates". Given that IACTs don't have
 a detector chip (or at least the FOV coordinates used in high-level analysis are
-different from the IACT camera coordinate detectors), it wasn't clear what to put,
+different from the IACT camera coordinate detectors), the definition is not unambiguous,
 both ``(DETX, DETY) = (FOV_ALTAZ_LON, FOV_ALTAZ_LAT)``
 and ``(DETX, DETY) = (FOV_RADEC_LON, FOV_RADEC_LAT)``
-and very early on even TAN projections were used.
+have been used.
 
-Given this situation that there is no concensus yet, one suggestion is to avoid
-putting FOV coordinates in EVENTS, or if they are added, to clearly state how
-they are defined. This still leaves the problem with the background models,
-in case they are non-radially symmetric. We expect CTA to make a decision and to define
-FOV coordinate systems soon, to resolve this issue.
+To resolve this ambiguity, we propose a header key ``FOVALIGN={ALTAZ,RADEC}'',
+specifying which definition of field-of-view coordinates is used.
+
+Given the situation that there is no concensus yet, one suggestion is to avoid putting
+FOV coordinates in EVENTS, or if they are added, to clearly state how they are defined.
 
 .. _coords-location:
 

--- a/source/irfs/full_enclosure/bkg/index.rst
+++ b/source/irfs/full_enclosure/bkg/index.rst
@@ -19,6 +19,7 @@ The ``BKG_2D`` format contains a 2-dimensional array of post-select background
 rate, stored in the :ref:`fits-arrays-bintable-hdu` format.
 
 Required columns:
+~~~~~~~~~~~~~~~~~
 
 * ``ENERG_LO``, ``ENERG_HI`` -- ndim: 1, unit: TeV
     * Reconstructed energy axis
@@ -31,6 +32,7 @@ Required columns:
 Recommended axis order: ``ENERGY``, ``THETA``
 
 Header keywords:
+~~~~~~~~~~~~~~~~
 
 As explained in :ref:`hduclass`, the following header keyword should be used to 
 declare the type of HDU:
@@ -54,6 +56,7 @@ The ``BKG_3D`` format contains a 3-dimensional array of post-select background
 rate, stored in the :ref:`fits-arrays-bintable-hdu` format.
 
 Required columns:
+~~~~~~~~~~~~~~~~~
 
 * ``ENERG_LO``, ``ENERG_HI`` -- ndim: 1, unit: TeV
     * Reconstructed energy axis
@@ -66,6 +69,7 @@ Required columns:
 Recommended axis order: ``ENERGY``, ``DETX``, ``DETY``
 
 Header keywords:
+~~~~~~~~~~~~~~~~
 
 As explained in :ref:`hduclass`, the following header keyword should be used to 
 declare the type of HDU:
@@ -77,6 +81,11 @@ declare the type of HDU:
 * ``HDUCLAS2`` = 'BKG'
 * ``HDUCLAS3`` = 'FULL-ENCLOSURE'
 * ``HDUCLAS4`` = 'BKG_3D'
+
+Further header keywords:
+
+* ``FOVALIGN`` = 'ALTAZ' / 'RADEC'
+    * Alignment of the field-of-view coordinate system (see :ref:`coords-fov`)
 
 Example data file: :download:`here <./bkg_3d_full_example.fits>`.
 


### PR DESCRIPTION
This PR introduces a new header keyword useful for field-of-view coordinates. Since there are two definitions in use, namely an Alt/Az-aligned system with
`DETX = FOV_ALTAZ_LON`
`DETY = FOV_ALTAZ_LAT`
and a RA/Dec-aligned system with
`DETX = FOV_RADEC_LON`
`DETY = FOV_RADEC_LAT`,
the new header keyword can be used to specify which definition was used in the construction of a 3D background model.

Note that this PR only proposed to add this keyword for the background IRF, not the EVENTS file (since it's unclear whether field-of-view coordinates should be listed there at all).
