### PR TITLE
Time updates

### DIFF
--- a/source/general/fits-arrays.rst
+++ b/source/general/fits-arrays.rst
@@ -7,7 +7,7 @@ FITS Multidimensional datasets
 
 As described e.g. `here <http://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/general/ogip_94_006/ogip_94_006.html>`__
 or `here <http://heasarc.gsfc.nasa.gov/docs/heasarc/caldb/docs/memos/cal_gen_92_003/cal_gen_92_003.html#tth_sEc4>`__
-or in the `FITS Standard`_,
+or in the `FITS standard`_,
 there are several ways to serialise multi-dimensional arrays and corresponding axis information in FITS files.
 
 Here we describe the schemes in use in gamma-ray astronomy and give examples.

--- a/source/general/time.rst
+++ b/source/general/time.rst
@@ -56,7 +56,7 @@ The reference time point is specified by the following FITS header keywords:
     * Time system, also referred as time scale (e.g. 'UT', 'UTC', 'TT', 'TAI')
 * ``TIMEREF`` type: string
     * Time reference frame, used for example for barycentric corrections
-      (options: 'LOCAL', 'SOLARSYSTEM', 'HELIOCENTRIC', 'GEOCENTRIC')
+      (options: 'TOPOCENTER', 'GEOCENTER', 'BARYCENTER', 'HELIOCENTER', and more see Table 31 of `FITS standard`_)
 
 See the `FITS standard`_ and the `FITS time paper`_ for further information.
 
@@ -71,15 +71,20 @@ In addition to that main way of specifying times as a floating point number wrt.
 the following header keys with date and time values as strings can be added.
 This is for convenience and humans reading the information. Usually science tools will not access
 this redundant and optional information. The time system used should be the one given by ``TIMESYS``.
+All values for the keywords mentioned here shall be ISO8601 date and time strings,
+``yyyy-mm-ddTHH:MM:SS.fff``.
+The precision is not fixed, so seconds or fractional seconds could be left out.
 
 * ``DATE-OBS`` type: string
-    * Observation start date (format: "yyyy-mm-dd")
-* ``TIME-OBS`` type: string
-    * Observation start time (format: "hh:mm:ss.sss...")
+    * Observation date, typically the start of observations if not defined otherwise in the comment
+* ``DATE-BEG`` type: string
+    * Observation start date
+* ``DATE-AVG`` type: string
+    * Average observation date
 * ``DATE-END`` type: string
-    * Observation end date (format: "yyyy-mm-dd")
+    * Observation end date
 * ``TIME-END`` type: string
-    * Observation end time (format: "hh:mm:ss.sss...")
+    * Observation end time
 
 Note that the FITS standard allows and it is quite common to instead put a
 ``TIME-OBS`` key with value "yyyy-mm-ddThh:mm:ss.sss..." and to omit the ``DATE-OBS`` key

--- a/source/general/time.rst
+++ b/source/general/time.rst
@@ -84,11 +84,6 @@ The precision is not fixed, so seconds or fractional seconds could be left out.
 * ``DATE-END`` type: string
     * Observation end date and time
 
-Note that the FITS standard allows and it is quite common to instead put a
-``TIME-OBS`` key with value "yyyy-mm-ddThh:mm:ss.sss..." and to omit the ``DATE-OBS`` key
-(see `Dictionary of Commonly Used FITS Keywords`_). If science tools access these fields,
-they should support both conventions.
-
 .. _time-tools:
 
 Tools
@@ -147,7 +142,7 @@ For high-level gamma-ray astronomy, the situation can be summarised like this
   which is sufficient for any high-level analysis (including milli-second pulsars).
 * **Do not use 32-bit floats for times.**
   If you do, times will be incorrect at the 1 to 100 second level.
-* **Double-float precision is not needed.**
+* More than 64-bit floats or a combination of two floating point numbers is not necessary
 
 For data acquisition and low-level analysis (event triggering, traces, ...),
 IACTs require nanosecond precision or better. There, the simple advice to use

--- a/source/general/time.rst
+++ b/source/general/time.rst
@@ -53,7 +53,7 @@ The reference time point is specified by the following FITS header keywords:
 * ``TIMEUNIT`` type: string
     * Time unit (e.g. 's')
 * ``TIMESYS`` type: string
-    * Time system, also referred as time scale (e.g. 'UT', 'UTC', 'TT', 'TAI')
+    * Time system, also referred as time scale (e.g. 'UT1', 'UTC', 'TT', 'TAI', see Table 30 of the `FITS standard`_)
 * ``TIMEREF`` type: string
     * Time reference frame, used for example for barycentric corrections
       (options: 'TOPOCENTER', 'GEOCENTER', 'BARYCENTER', 'HELIOCENTER', and more see Table 31 of the `FITS standard`_)

--- a/source/general/time.rst
+++ b/source/general/time.rst
@@ -76,15 +76,13 @@ All values for the keywords mentioned here shall be ISO8601 date and time string
 The precision is not fixed, so seconds or fractional seconds could be left out.
 
 * ``DATE-OBS`` type: string
-    * Observation date, typically the start of observations if not defined otherwise in the comment
+    * Observation date and time, typically the start of observations if not defined otherwise in the comment
 * ``DATE-BEG`` type: string
-    * Observation start date
+    * Observation start date and time
 * ``DATE-AVG`` type: string
-    * Average observation date
+    * Average observation date and time
 * ``DATE-END`` type: string
-    * Observation end date
-* ``TIME-END`` type: string
-    * Observation end time
+    * Observation end date and time
 
 Note that the FITS standard allows and it is quite common to instead put a
 ``TIME-OBS`` key with value "yyyy-mm-ddThh:mm:ss.sss..." and to omit the ``DATE-OBS`` key

--- a/source/general/time.rst
+++ b/source/general/time.rst
@@ -56,7 +56,7 @@ The reference time point is specified by the following FITS header keywords:
     * Time system, also referred as time scale (e.g. 'UT', 'UTC', 'TT', 'TAI')
 * ``TIMEREF`` type: string
     * Time reference frame, used for example for barycentric corrections
-      (options: 'TOPOCENTER', 'GEOCENTER', 'BARYCENTER', 'HELIOCENTER', and more see Table 31 of `FITS standard`_)
+      (options: 'TOPOCENTER', 'GEOCENTER', 'BARYCENTER', 'HELIOCENTER', and more see Table 31 of the `FITS standard`_)
 
 See the `FITS standard`_ and the `FITS time paper`_ for further information.
 

--- a/source/references.txt
+++ b/source/references.txt
@@ -24,7 +24,7 @@
 .. _Readthedocs: https://readthedocs.org
 .. _Sphinx RTD theme FAQ entry: http://docs.readthedocs.io/en/latest/faq.html#i-want-to-use-the-read-the-docs-theme-locally
 .. _WCSLIB: http://www.atnf.csiro.au/people/mcalabre/WCS/
-.. _FITS standard: http://adsabs.harvard.edu/abs/2010A%26A...524A..42P
+.. _FITS standard: https://fits.gsfc.nasa.gov/standard40/fits_standard40aa-le.pdf
 .. _FITS WCS: http://fits.gsfc.nasa.gov/fits_wcs.html
 .. _FITS time paper: http://adsabs.harvard.edu/abs/2015A%26A...574A..36R
 .. _Dictionary of Commonly Used FITS Keywords: https://heasarc.gsfc.nasa.gov/docs/fcg/common_dict.html


### PR DESCRIPTION
Updates the time definition keywords to how they are defined in the current FITS standard 4.0.

Basically merges `DATE-*` and `TIME-*` into `DATE-*` with a full ISO8601 date and time string