### PR TITLE
Update index.rst

### DIFF
--- a/source/irfs/index.rst
+++ b/source/irfs/index.rst
@@ -14,9 +14,7 @@ as well as for the IRFs that are distributed with the Fermi-LAT science tools.
 
 Two different approaches are used to store the IRF of IACTs:
 
-* Full-enclosure IRF: all IRF components are stored as a function of the offset with respect to the source 
-  position.
- 
+* Full-enclosure IRF: all IRF components are stored as a function of the offset with respect to the pointing direction
 * Point-like IRF: IRF components are calculated after applying a cut in direction offset. This format has been 
   used by the current generation of IACTs to perform spectral analysis and light curves.
 


### PR DESCRIPTION
It is not correct to define radial distance  with respect to "source position". The source could be anywhere, there could be several, or none.
I propose to change "source position" by "pointing direction", but also there can be more than one pointing direction for e.g. divergent observation mode, so probably it would be better to use "center of the field of view"  and define it as e.g. the direction with respect to which the observed field of view is symmetric in terms of exposure (this definition needs to be polished a bit, but you probably see the point...)