### PR TITLE
Make RA/Dec pointing optional to include wide-field ground array instruments

### DIFF
--- a/source/data_storage/index.rst
+++ b/source/data_storage/index.rst
@@ -1,7 +1,7 @@
 .. _iact-storage:
 
-IACT data storage
-=================
+Data storage
+============
 
 At the moment there is no agreed way to organise IACT data, and how to connect
 ``EVENTS`` with IRFs or other information such as time or pointing information

--- a/source/events/events.rst
+++ b/source/events/events.rst
@@ -115,6 +115,8 @@ An observatory Earth location should be given as well (see :ref:`coords-location
 * ``DEADC`` type: float
     * Dead time correction, defined by ``LIVETIME/ONTIME``.
       Is comprised in [0,1]. Defined to be 0 if ``ONTIME=0``.
+* ``OBS_MODE`` type: string
+    * Observation mode. See notes on :ref:`iact-events-obs-mode` below.
 * ``RA_PNT`` type: float, unit: deg
     * Pointing Right Ascension (see :ref:`coords-radec`). Not mandatory if ``OBS_MODE=DRIFT``, but average values could optionally be provided.
 * ``DEC_PNT`` type: float, unit: deg
@@ -170,9 +172,7 @@ Optional header keywords
 * ``RA_OBJ`` type: float, unit: deg
     * Right ascension of ``OBJECT``
 * ``DEC_OBJ`` type: float, unit: deg
-    * Declination of ``OBJECT``                
-* ``OBS_MODE`` type: string
-    * Observation mode. See notes on :ref:`iact-events-obs-mode` below.
+    * Declination of ``OBJECT``
 * ``EV_CLASS`` type: str
     * Event class. See notes on :ref:`iact-events-class-type` below.
 * ``TELAPSE`` type: float, unit: s
@@ -336,13 +336,10 @@ different types of insrument. More details can be found
 `here <https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/general/ogip_94_001/ogip_94_001.html>`__
 
 Additionally to the OGIP-defined values (``POINTING``, ``RASTER``, ``SLEW`` and ``SCAN``), we
-propose an additional option ``DRIFT`` to accomodate ground-based instruments, in
+define an additional option ``DRIFT`` to accomodate ground-based instruments, in
 which local zenith/azimuth coordinates remain constant. In this case, the header keywords
 ``RA_PNT`` and ``DEC_PNT`` are no longer mandatory, and instead ``ALT_PNT`` and ``AZ_PNT``
 are required.
-
-This keyword is optional, which means that in its absence, the default becomes to consider
-``RA_PNT`` and ``DEC_PNT`` as mandatory.
 
 It is likely that ``OBS_MODE`` in the future will be a key piece of information
 in the DL3 data model, defining the observation mode (e.g. pointed, divergent,

--- a/source/events/events.rst
+++ b/source/events/events.rst
@@ -115,10 +115,10 @@ An observatory Earth location should be given as well (see :ref:`coords-location
 * ``DEADC`` type: float
     * Dead time correction, defined by ``LIVETIME/ONTIME``.
       Is comprised in [0,1]. Defined to be 0 if ``ONTIME=0``.
-* ``ALT_PNT`` type: float, unit: deg
-    * Pointing altitude (see :ref:`coords-altaz`).
-* ``AZ_PNT`` type: float, unit: deg
-    * Pointing azimuth (see :ref:`coords-altaz`).
+* ``RA_PNT`` type: float, unit: deg
+    * Pointing Right Ascension (see :ref:`coords-radec`).
+* ``DEC_PNT`` type: float, unit: deg
+    * Pointing declination (see :ref:`coords-radec`).
 * ``EQUINOX`` type: float
     * Equinox in years for the celestial coordinate system in which positions
       given in either the header or data are expressed (options: 2000.0).
@@ -161,10 +161,6 @@ Optional header keywords
 * ``CREATED`` type: string
     * Time when file was created in ISO standard date representation
       "ccyy-mm-ddThh:mm:ss" (UTC)
-* ``RA_PNT`` type: float, unit: deg
-    * Pointing Right Ascension (see :ref:`coords-radec`).
-* ``DEC_PNT`` type: float, unit: deg
-    * Pointing declination (see :ref:`coords-radec`).
 * ``OBJECT`` type: string
     * Observed object (e.g. 'Crab')
 * ``RA_OBJ`` type: float, unit: deg

--- a/source/events/events.rst
+++ b/source/events/events.rst
@@ -116,13 +116,13 @@ An observatory Earth location should be given as well (see :ref:`coords-location
     * Dead time correction, defined by ``LIVETIME/ONTIME``.
       Is comprised in [0,1]. Defined to be 0 if ``ONTIME=0``.
 * ``RA_PNT`` type: float, unit: deg
-    * Pointing Right Ascension (see :ref:`coords-radec`). Not required if ``OBS_MODE=DRIFT``
+    * Pointing Right Ascension (see :ref:`coords-radec`). Not mandatory if ``OBS_MODE=DRIFT``, but average values could optionally be provided.
 * ``DEC_PNT`` type: float, unit: deg
-    * Pointing declination (see :ref:`coords-radec`). Not required if ``OBS_MODE=DRIFT``
+    * Pointing declination (see :ref:`coords-radec`). Not mandatory if ``OBS_MODE=DRIFT``, but average values could optionally be provided.
 * ``ALT_PNT`` type: float, unit: deg
-    * Pointing Altitude (see :ref:`coords-altaz`). Only required if ``OBS_MODE=DRIFT``
+    * Pointing Altitude (see :ref:`coords-altaz`). Only mandatory if ``OBS_MODE=DRIFT``
 * ``AZ_PNT`` type: float, unit: deg
-    * Pointing azimuth (see :ref:`coords-altaz`). Only required if ``OBS_MODE=DRIFT``
+    * Pointing azimuth (see :ref:`coords-altaz`). Only mandatory if ``OBS_MODE=DRIFT``
 * ``EQUINOX`` type: float
     * Equinox in years for the celestial coordinate system in which positions
       given in either the header or data are expressed (options: 2000.0).

--- a/source/events/events.rst
+++ b/source/events/events.rst
@@ -115,10 +115,10 @@ An observatory Earth location should be given as well (see :ref:`coords-location
 * ``DEADC`` type: float
     * Dead time correction, defined by ``LIVETIME/ONTIME``.
       Is comprised in [0,1]. Defined to be 0 if ``ONTIME=0``.
-* ``RA_PNT`` type: float, unit: deg
-    * Pointing Right Ascension (see :ref:`coords-radec`).
-* ``DEC_PNT`` type: float, unit: deg
-    * Pointing declination (see :ref:`coords-radec`).
+* ``ALT_PNT`` type: float, unit: deg
+    * Pointing altitude (see :ref:`coords-altaz`).
+* ``AZ_PNT`` type: float, unit: deg
+    * Pointing azimuth (see :ref:`coords-altaz`).
 * ``EQUINOX`` type: float
     * Equinox in years for the celestial coordinate system in which positions
       given in either the header or data are expressed (options: 2000.0).
@@ -161,6 +161,10 @@ Optional header keywords
 * ``CREATED`` type: string
     * Time when file was created in ISO standard date representation
       "ccyy-mm-ddThh:mm:ss" (UTC)
+* ``RA_PNT`` type: float, unit: deg
+    * Pointing Right Ascension (see :ref:`coords-radec`).
+* ``DEC_PNT`` type: float, unit: deg
+    * Pointing declination (see :ref:`coords-radec`).
 * ``OBJECT`` type: string
     * Observed object (e.g. 'Crab')
 * ``RA_OBJ`` type: float, unit: deg

--- a/source/events/events.rst
+++ b/source/events/events.rst
@@ -332,11 +332,11 @@ OBS_MODE
 The keyword ``OBS_MODE`` specifies the mode of the observation.
 This is used in cases where the instrument or detector can be configured to
 operate in different modes which significantly affect the resulting data, or to accomodate
-different types of insrument. More details can be found
+different types of instrument. More details can be found
 `here <https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/general/ogip_94_001/ogip_94_001.html>`__
 
-Additionally to the OGIP-defined values (``POINTING``, ``RASTER``, ``SLEW`` and ``SCAN``), we
-define an additional option ``DRIFT`` to accomodate ground-based instruments, in
+In addition to the OGIP-defined values (``POINTING``, ``RASTER``, ``SLEW`` and ``SCAN``), we
+define the option ``DRIFT`` to accomodate ground-based wide-field instruments, in
 which local zenith/azimuth coordinates remain constant. In this case, the header keywords
 ``RA_PNT`` and ``DEC_PNT`` are no longer mandatory, and instead ``ALT_PNT`` and ``AZ_PNT``
 are required.

--- a/source/events/events.rst
+++ b/source/events/events.rst
@@ -116,9 +116,13 @@ An observatory Earth location should be given as well (see :ref:`coords-location
     * Dead time correction, defined by ``LIVETIME/ONTIME``.
       Is comprised in [0,1]. Defined to be 0 if ``ONTIME=0``.
 * ``RA_PNT`` type: float, unit: deg
-    * Pointing Right Ascension (see :ref:`coords-radec`).
+    * Pointing Right Ascension (see :ref:`coords-radec`). Not required if ``OBS_MODE=DRIFT``
 * ``DEC_PNT`` type: float, unit: deg
-    * Pointing declination (see :ref:`coords-radec`).
+    * Pointing declination (see :ref:`coords-radec`). Not required if ``OBS_MODE=DRIFT``
+* ``ALT_PNT`` type: float, unit: deg
+    * Pointing Altitude (see :ref:`coords-altaz`). Only required if ``OBS_MODE=DRIFT``
+* ``AZ_PNT`` type: float, unit: deg
+    * Pointing azimuth (see :ref:`coords-altaz`). Only required if ``OBS_MODE=DRIFT``
 * ``EQUINOX`` type: float
     * Equinox in years for the celestial coordinate system in which positions
       given in either the header or data are expressed (options: 2000.0).
@@ -322,16 +326,23 @@ CTA and discussion, and then a proposal for a specification.
 
 .. _iact-events-obs-mode:
 
-OBS_MODE 
+OBS_MODE
 ~~~~~~~~
 
-The observation mode ``OBS_MODE`` is currently provenance information, not used
-by science tools to decide how to analyse the data. There is no set of defined
-modes yet. Thus, at the moment it is optional.
+The keyword ``OBS_MODE`` specifies the mode of the observation.
+This is used in cases where the instrument or detector can be configured to
+operate in different modes which significantly affect the resulting data, or to accomodate
+different types of insrument. More details can be found
+`here <https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/general/ogip_94_001/ogip_94_001.html>`__
 
-Just to give an example: in H.E.S.S. the values of "WOBBLE" for wobble
-observations (pointing slightly off target) and "SCAN" for Galactic plane survey
-observation on a grid of sky positions (not wrt. a specific target) is used.
+Additionally to the OGIP-defined values (``POINTING``, ``RASTER``, ``SLEW`` and ``SCAN``), we
+propose an additional option ``DRIFT`` to accomodate ground-based instruments, in
+which local zenith/azimuth coordinates remain constant. In this case, the header keywords
+``RA_PNT`` and ``DEC_PNT`` are no longer mandatory, and instead ``ALT_PNT`` and ``AZ_PNT``
+are required.
+
+This keyword is optional, which means that in its absence, the default becomes to consider
+``RA_PNT`` and ``DEC_PNT`` as mandatory.
 
 It is likely that ``OBS_MODE`` in the future will be a key piece of information
 in the DL3 data model, defining the observation mode (e.g. pointed, divergent,

--- a/source/events/index.rst
+++ b/source/events/index.rst
@@ -1,9 +1,9 @@
 .. include:: ../references.txt
 
-IACT events
-===========
+Events
+======
 
-This document describes the format to store DL3 event data for IACTs.
+This document describes the format to store DL3 event data for gamma-ray instruments.
 
 The main table is ``EVENTS``, which at the moment contains not only event
 parameters, but also key information about the observation needed to analyse the

--- a/source/irfs/index.rst
+++ b/source/irfs/index.rst
@@ -2,8 +2,8 @@
 
 .. _iact-irf:
 
-IACT IRFs
-=========
+IRFs
+====
 
 The instrument response function (IRF) format currently in use
 for imaging atmospheric Cherenkov telescopes (IACTs) are stored in FITS

--- a/source/irfs/index.rst
+++ b/source/irfs/index.rst
@@ -6,13 +6,14 @@ IRFs
 ====
 
 The instrument response function (IRF) format currently in use
-for imaging atmospheric Cherenkov telescopes (IACTs) are stored in FITS
-binary tables using the "multidimensional array" convention (binary tables with a
+for gamma-ray instruments and, in particular, imaging atmospheric 
+Cherenkov telescopes (IACTs) are stored in FITS binary tables using 
+the "multidimensional array" convention (binary tables with a
 single row and array columns) described at :ref:`fits-arrays-bintable-hdu`. 
 This format has been used for calibration data and IRF of X-ray instruments,
 as well as for the IRFs that are distributed with the Fermi-LAT science tools.
 
-Two different approaches are used to store the IRF of IACTs:
+Two different approaches are used to store the IRF of gamma-ray instruments:
 
 * Full-enclosure IRF: all IRF components are stored as a function of the offset with respect to the source 
   position.


### PR DESCRIPTION
Hi all,

As we discussed in the issue #167, I've made some small changes to make the format inclusive to wide-field instruments, such as HAWC.

- I've removed the word IACT from every section title and replaced it by "gamma-ray instrument" whenever was possible for some instances in the main text. The result is still pretty IACT-centric, but at least is a little better now :smile: 
- The headers `RA_PNT`, `DEC_PNT` in the event lists are now optional, and instead, `AZ_PNT` and `ALT_PNT` are mandatory, which keeps the pointing information in the mandatory headers, while allowing wide-field  instruments to set these to some fixed value (zenith) and remain compatible.

For this last point, however, it is important to distinguish what type of purpose would this pointing information be used for.  I would distinguish between the concept of pointing as the definition of the central axis of the telescope, in which, indeed, a fixed pointing at zenith would be accurate for ground arrays, or, for example, pointing understood as information about the events inside a run, i.e. if at any point you select observations by their pointing position. This second option would not make sense for wide-field data, and also wouldn't make sense for local coordinates pointing without timing information. I don't know if this is ever used like that at the moment, but I think it should be distinguished carefully. Something to note is that, while a typical IACT run is in the order of tens of minutes, a standard "observation" for a ground array, that is, a period in which the detector remains stable is usually much longer.

That is why I didn't touch the `POINTING` section because I don't know exactly what it would be used for.

Please let me know what your thoughts are and if you think I should change anything!