### PR TITLE
Added optional gammaness column in EVENTS hdu

### DIFF
--- a/source/events/events.rst
+++ b/source/events/events.rst
@@ -60,6 +60,8 @@ Optional columns
     * Reconstructed field of view offset angle (see :ref:`coords-fov`).
 * ``PHI`` type: float, unit: deg
     * Reconstructed field of view position angle (see :ref:`coords-fov`).
+* ``GAMMANESS`` type: float
+    * Classification score of a signal / background separation. SHOULD be between 0 and 1, with higher values indicating larger confidence that the event was produced by a gamma ray.
 * ``DIR_ERR`` type: float, unit: deg
     * Direction error of reconstruction 
 * ``ENERGY_ERR`` type: float, unit: TeV


### PR DESCRIPTION
Shamelessly copying from what @maxnoe has just suggested in issue #34, a PR adding the optional `gammaness` column.
@maxnoe, from your suggestion I have replaced "this shower was induced by a gamma ray" with "the event was produced by a gamma ray", if we have to include gamma-ray satellites - though one can argue that what develops in a pair-conversion satellite is indeed a shower. But I thought it would be better to keep it more general.