### PR TITLE
Add rad max to possible HDU index values

### DIFF
--- a/source/data_storage/hdu_index/index.rst
+++ b/source/data_storage/hdu_index/index.rst
@@ -82,6 +82,7 @@ Valid ``HDU_TYPE`` values:
 * ``psf`` - Point spread function
 * ``edisp`` - Energy dispersion
 * ``bkg`` - Background
+* ``rad_max`` - Directional cut for point-like IRFs
 
 Valid ``HDU_CLASS`` values:
 
@@ -94,6 +95,7 @@ Valid ``HDU_CLASS`` values:
 * ``psf_king`` - see format spec: :ref:`psf_king`
 * ``bkg_2d`` - see format spec: :ref:`bkg_2d`
 * ``bkg_3d`` - see format spec: :ref:`bkg_3d`
+* ``rad_max_2d`` - see format spec: :ref:`rad_max_2d`
 
 
 Relation to HDUCLAS


### PR DESCRIPTION
The rad max tables were missing from the HDU index table description.