### PR TITLE
Add support for time keywords for sky map axes

### DIFF
--- a/source/skymaps/index.rst
+++ b/source/skymaps/index.rst
@@ -84,7 +84,11 @@ Header Keywords
       lower and upper edges of each bin.  If there is a single element
       the column should be interpreted as the bin center.  For
       ``EBOUNDS`` or ``ENERGIES`` HDUs this keyword is optional.
-  
+
+For time based axes the additional keywords described in `time-formats`_ are
+allowed.
+
+
 Columns
 ~~~~~~~
 

--- a/source/skymaps/index.rst
+++ b/source/skymaps/index.rst
@@ -86,7 +86,7 @@ Header Keywords
       ``EBOUNDS`` or ``ENERGIES`` HDUs this keyword is optional.
 
 For time based axes the additional keywords described in `time-formats`_ are
-allowed.
+required.
 
 
 Columns


### PR DESCRIPTION
This PR adds a small addition to support additional keywords for time based map axes, based on the same time format standards used elsewhere in GADF.