### PR TITLE
Remove deployment to github pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,14 +23,3 @@ jobs:
 
       - name: Build
         run: poetry run make html SPHINXOPTS="-W --keep-going -n --color -j auto"
-
-      - name: Deploy to gihub pages
-        # only run on push to master
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
-        uses: JamesIves/github-pages-deploy-action@4.1.7
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: gh-pages
-          FOLDER: build/html
-          CLEAN: true
-          SINGLE_COMMIT: true


### PR DESCRIPTION
As discussed in #188, we prefer to only use readthedocs.

It seems the readthedocs config only missed the option to use `master` as the default branch for the `latest` version, this is now fixed.

So merging this PR will remove the upload to github pages and should now trigger an automatic rebuild on RTD