### PR TITLE
Add sentence about OBS_MODE for IACTs

### DIFF
--- a/source/events/events.rst
+++ b/source/events/events.rst
@@ -337,6 +337,8 @@ operate in different modes which significantly affect the resulting data, or to 
 different types of instrument. More details can be found
 `here <https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/general/ogip_94_001/ogip_94_001.html>`__
 
+Most IACT data will be ``POINTING``, indicating a constant pointing in equatorial coordinates.
+
 In addition to the OGIP-defined values (``POINTING``, ``RASTER``, ``SLEW`` and ``SCAN``), we
 define the option ``DRIFT`` to accomodate ground-based wide-field instruments, in
 which local zenith/azimuth coordinates remain constant. In this case, the header keywords


### PR DESCRIPTION
There was some confusion regarding OBS_MODE in LST in the current dev version, has the OGIP defined values only talk about satellites.

I added a note that most IACT data should use POINTING, indiciating constant equatorial values for the observation.